### PR TITLE
cloudwatch-mcp-server: add Lambda handler and Lambda image packaging

### DIFF
--- a/src/cloudwatch-mcp-server/Dockerfile
+++ b/src/cloudwatch-mcp-server/Dockerfile
@@ -1,77 +1,14 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Lambda container image for the CloudWatch MCP server.
+FROM public.ecr.aws/lambda/python:3.13
 
-FROM public.ecr.aws/sam/build-python3.10@sha256:84738adb2767299571443d742c006d2f153c809c7181b099468583ac97be2dda AS uv
+WORKDIR ${LAMBDA_TASK_ROOT}
 
-# Install the project into `/app`
-WORKDIR /app
+# Install the package and runtime dependencies.
+COPY pyproject.toml README.md LICENSE NOTICE ./
+COPY awslabs ./awslabs
 
-# Enable bytecode compilation
-ENV UV_COMPILE_BYTECODE=1
+RUN pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir .
 
-# Copy from the cache instead of linking since it's a mounted volume
-ENV UV_LINK_MODE=copy
-
-# Prefer the system python
-ENV UV_PYTHON_PREFERENCE=only-system
-
-# Run without updating the uv.lock file like running with `--frozen`
-ENV UV_FROZEN=true
-
-# Copy the required files first
-COPY pyproject.toml uv.lock ./
-
-# Install the project's dependencies using the lockfile and settings
-RUN --mount=type=cache,target=/root/.cache/uv \
-    pip install uv==0.7.11 && \
-    uv sync --frozen --no-install-project --no-dev --no-editable
-
-# Then, add the rest of the project source code and install it
-# Installing separately from its dependencies allows optimal layer caching
-COPY . /app
-RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --frozen --no-dev --no-editable
-
-# Make the directory just in case it doesn't exist
-RUN mkdir -p /root/.local
-
-FROM public.ecr.aws/sam/build-python3.10@sha256:84738adb2767299571443d742c006d2f153c809c7181b099468583ac97be2dda
-
-# Place executables in the environment at the front of the path and include other binaries
-ENV PATH="/app/.venv/bin:$PATH:/usr/sbin"
-
-# Install lsof for the healthcheck
-# Install other tools as needed for the MCP server
-# Add non-root user and ability to change directory into /root
-RUN yum update -y && \
-    yum install -y lsof && \
-    yum clean all -y && \
-    rm -rf /var/cache/yum && \
-    groupadd --force --system app && \
-    useradd app -g app -d /app && \
-    chmod o+x /root
-
-# Get the project from the uv layer
-COPY --from=uv --chown=app:app /root/.local /root/.local
-COPY --from=uv --chown=app:app /app/.venv /app/.venv
-
-# Get healthcheck script
-COPY ./docker-healthcheck.sh /usr/local/bin/docker-healthcheck.sh
-
-# Run as non-root
-USER app
-
-# When running the container, add --db-path and a bind mount to the host's db file
-HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 CMD [ "docker-healthcheck.sh" ]
-ENTRYPOINT ["awslabs.cloudwatch-mcp-server"]
+# Lambda runtime handler entrypoint.
+CMD ["awslabs.cloudwatch_mcp_server.lambda_handler.lambda_handler"]

--- a/src/cloudwatch-mcp-server/awslabs/cloudwatch_mcp_server/lambda_handler.py
+++ b/src/cloudwatch-mcp-server/awslabs/cloudwatch_mcp_server/lambda_handler.py
@@ -1,0 +1,221 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""AWS Lambda handler for the CloudWatch MCP Server."""
+
+import json
+import os
+from typing import Any, Dict, Optional
+
+from awslabs.cloudwatch_mcp_server import MCP_SERVER_VERSION
+from awslabs.cloudwatch_mcp_server.cloudwatch_alarms.tools import CloudWatchAlarmsTools
+from awslabs.cloudwatch_mcp_server.cloudwatch_logs.tools import CloudWatchLogsTools
+from awslabs.cloudwatch_mcp_server.cloudwatch_metrics.tools import CloudWatchMetricsTools
+from awslabs.mcp_lambda_handler import MCPLambdaHandler
+from loguru import logger
+
+
+def get_oauth_config() -> Dict[str, str]:
+    """Get OAuth configuration from environment variables."""
+    return {
+        'issuer': os.environ.get(
+            'OAUTH_ISSUER',
+            'https://cognito-idp.eu-west-1.amazonaws.com/eu-west-1_FejeFJmNE',
+        ),
+        'authorization_endpoint': os.environ.get(
+            'OAUTH_AUTHORIZATION_ENDPOINT',
+            'https://carlsberg-healthomics-auth.auth.eu-west-1.amazoncognito.com/oauth2/authorize',
+        ),
+        'token_endpoint': os.environ.get(
+            'OAUTH_TOKEN_ENDPOINT',
+            'https://carlsberg-healthomics-auth.auth.eu-west-1.amazoncognito.com/oauth2/token',
+        ),
+        'client_id': os.environ.get('OAUTH_CLIENT_ID', '6r52ekr37jn84nlusjgn6j7f8m'),
+        'base_url': os.environ.get(
+            'MCP_SERVER_BASE_URL',
+            'https://osgs2j07zf.execute-api.eu-west-1.amazonaws.com/stable',
+        ),
+    }
+
+
+def get_oauth_metadata(base_url: str = '') -> Dict[str, Any]:
+    """Get OAuth 2.0 Authorization Server Metadata."""
+    config = get_oauth_config()
+    effective_base_url = base_url or config['base_url']
+
+    metadata = {
+        'issuer': config['issuer'],
+        'authorization_endpoint': config['authorization_endpoint'],
+        'token_endpoint': config['token_endpoint'],
+        'response_types_supported': ['code'],
+        'grant_types_supported': ['authorization_code', 'refresh_token'],
+        'code_challenge_methods_supported': ['S256'],
+        'token_endpoint_auth_methods_supported': ['none', 'client_secret_post'],
+        'scopes_supported': ['openid', 'email', 'profile'],
+    }
+
+    if effective_base_url:
+        metadata['registration_endpoint'] = f'{effective_base_url}/register'
+
+    return metadata
+
+
+def get_base_url(event: Dict[str, Any]) -> str:
+    """Extract base URL from API Gateway event."""
+    request_context = event.get('requestContext', {})
+
+    if 'domainName' in request_context:
+        domain = request_context['domainName']
+        stage = request_context.get('stage', '')
+        if stage and stage != '$default':
+            return f'https://{domain}/{stage}'
+        return f'https://{domain}'
+
+    headers = event.get('headers', {})
+    host = headers.get('Host') or headers.get('host', '')
+    if host:
+        return f'https://{host}'
+
+    return ''
+
+
+def handle_oauth_discovery(event: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Serve OAuth/OIDC discovery documents on public endpoints."""
+    path = event.get('path', '') or event.get('rawPath', '')
+    base_url = get_base_url(event)
+
+    if path.endswith('/.well-known/oauth-authorization-server') or path == (
+        '/.well-known/oauth-authorization-server'
+    ):
+        return {
+            'statusCode': 200,
+            'headers': {
+                'Content-Type': 'application/json',
+                'Access-Control-Allow-Origin': '*',
+                'Cache-Control': 'public, max-age=3600',
+            },
+            'body': json.dumps(get_oauth_metadata(base_url)),
+        }
+
+    if path.endswith('/.well-known/openid-configuration') or path == (
+        '/.well-known/openid-configuration'
+    ):
+        metadata = get_oauth_metadata(base_url)
+        metadata['id_token_signing_alg_values_supported'] = ['RS256']
+        metadata['subject_types_supported'] = ['public']
+        return {
+            'statusCode': 200,
+            'headers': {
+                'Content-Type': 'application/json',
+                'Access-Control-Allow-Origin': '*',
+                'Cache-Control': 'public, max-age=3600',
+            },
+            'body': json.dumps(metadata),
+        }
+
+    return None
+
+
+def handle_dynamic_client_registration(event: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Handle RFC 7591 Dynamic Client Registration requests."""
+    path = event.get('path', '') or event.get('rawPath', '')
+    method = event.get('httpMethod', '') or event.get('requestContext', {}).get('http', {}).get(
+        'method', ''
+    )
+
+    if (path.endswith('/register') or path == '/register') and method == 'POST':
+        body = event.get('body', '{}')
+        if event.get('isBase64Encoded'):
+            import base64
+
+            body = base64.b64decode(body).decode('utf-8')
+
+        try:
+            registration_request = json.loads(body) if body else {}
+        except json.JSONDecodeError:
+            registration_request = {}
+
+        config = get_oauth_config()
+        client_response = {
+            'client_id': config['client_id'],
+            'client_name': registration_request.get('client_name', 'ChatGPT MCP Client'),
+            'redirect_uris': registration_request.get('redirect_uris', []),
+            'grant_types': ['authorization_code', 'refresh_token'],
+            'response_types': ['code'],
+            'token_endpoint_auth_method': 'none',
+            'client_id_issued_at': 0,
+            'client_secret_expires_at': 0,
+        }
+        return {
+            'statusCode': 201,
+            'headers': {
+                'Content-Type': 'application/json',
+                'Access-Control-Allow-Origin': '*',
+                'Cache-Control': 'no-store',
+            },
+            'body': json.dumps(client_response),
+        }
+
+    return None
+
+
+mcp = MCPLambdaHandler(
+    name='awslabs.cloudwatch-mcp-server',
+    version=MCP_SERVER_VERSION,
+)
+
+
+logs_tools = CloudWatchLogsTools()
+metrics_tools = CloudWatchMetricsTools()
+alarms_tools = CloudWatchAlarmsTools()
+
+
+def _register_lambda_tool(tool_name: str, tool_fn: Any) -> None:
+    """Register tool function under a stable MCP name."""
+    target_fn = tool_fn.__func__ if hasattr(tool_fn, '__func__') else tool_fn
+    original_name = target_fn.__name__
+    target_fn.__name__ = tool_name
+    try:
+        mcp.tool()(tool_fn)
+    finally:
+        target_fn.__name__ = original_name
+
+
+_register_lambda_tool('describeLogGroups', logs_tools.describe_log_groups)
+_register_lambda_tool('analyzeLogGroup', logs_tools.analyze_log_group)
+_register_lambda_tool('executeLogInsightsQuery', logs_tools.execute_log_insights_query)
+_register_lambda_tool('getLogsInsightQueryResults', logs_tools.get_logs_insight_query_results)
+_register_lambda_tool('cancelLogsInsightQuery', logs_tools.cancel_logs_insight_query)
+
+_register_lambda_tool('getMetricData', metrics_tools.get_metric_data)
+_register_lambda_tool('getMetricMetadata', metrics_tools.get_metric_metadata)
+_register_lambda_tool('getRecommendedMetricAlarms', metrics_tools.get_recommended_metric_alarms)
+
+_register_lambda_tool('getActiveAlarms', alarms_tools.get_active_alarms)
+_register_lambda_tool('getAlarmHistory', alarms_tools.get_alarm_history)
+
+
+def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
+    """AWS Lambda entrypoint for CloudWatch MCP Server."""
+    logger.info('CloudWatch MCP Lambda handler invoked')
+
+    oauth_response = handle_oauth_discovery(event)
+    if oauth_response:
+        return oauth_response
+
+    dcr_response = handle_dynamic_client_registration(event)
+    if dcr_response:
+        return dcr_response
+
+    return mcp.handle_request(event, context)

--- a/src/cloudwatch-mcp-server/awslabs/mcp_lambda_handler/__init__.py
+++ b/src/cloudwatch-mcp-server/awslabs/mcp_lambda_handler/__init__.py
@@ -1,0 +1,19 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""awslabs.mcp_lambda_handler: AWS Lambda MCP Server package."""
+
+__version__ = '0.1.4'
+
+from .mcp_lambda_handler import MCPLambdaHandler

--- a/src/cloudwatch-mcp-server/awslabs/mcp_lambda_handler/mcp_lambda_handler.py
+++ b/src/cloudwatch-mcp-server/awslabs/mcp_lambda_handler/mcp_lambda_handler.py
@@ -1,0 +1,530 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import functools
+import inspect
+import json
+import logging
+from awslabs.mcp_lambda_handler.session import DynamoDBSessionStore, NoOpSessionStore, SessionStore
+from awslabs.mcp_lambda_handler.types import (
+    Capabilities,
+    ErrorContent,
+    InitializeResult,
+    JSONRPCError,
+    JSONRPCRequest,
+    JSONRPCResponse,
+    ServerInfo,
+    TextContent,
+)
+from contextvars import ContextVar
+from enum import Enum
+from pydantic.fields import FieldInfo
+from pydantic_core import PydanticUndefined
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Generic,
+    List,
+    Optional,
+    TypeVar,
+    Union,
+    get_args,
+    get_origin,
+    get_type_hints,
+)
+
+
+logger = logging.getLogger(__name__)
+
+# Context variable to store current session ID
+current_session_id: ContextVar[Optional[str]] = ContextVar('current_session_id', default=None)
+
+T = TypeVar('T')
+
+
+class SessionData(Generic[T]):
+    """Helper class for type-safe session data access."""
+
+    def __init__(self, data: Dict[str, Any]):
+        """Initialize the class."""
+        self._data = data
+
+    def get(self, key: str, default: T = None) -> T:
+        """Get a value from session data with type safety."""
+        return self._data.get(key, default)
+
+    def set(self, key: str, value: T) -> None:
+        """Set a value in session data."""
+        self._data[key] = value
+
+    def raw(self) -> Dict[str, Any]:
+        """Get the raw dictionary data."""
+        return self._data
+
+
+class MCPLambdaHandler:
+    """A class to handle MCP (Model Context Protocol) HTTP events in AWS Lambda."""
+
+    def __init__(
+        self,
+        name: str,
+        version: str = '1.0.0',
+        session_store: Optional[Union[SessionStore, str]] = None,
+    ):
+        """Initialize the MCP handler.
+
+        Args:
+            name: Handler name
+            version: Handler version
+            session_store: Optional session storage. Can be:
+                         - None for no sessions
+                         - A SessionStore instance
+                         - A string for DynamoDB table name (for backwards compatibility)
+
+        """
+        self.name = name
+        self.version = version
+        self.tools: Dict[str, Dict] = {}
+        self.tool_implementations: Dict[str, Callable] = {}
+
+        # Configure session storage
+        if session_store is None:
+            self.session_store = NoOpSessionStore()
+        elif isinstance(session_store, str):
+            # Backwards compatibility - treat string as DynamoDB table name
+            self.session_store = DynamoDBSessionStore(table_name=session_store)
+        else:
+            self.session_store = session_store
+
+    def get_session(self) -> Optional[SessionData]:
+        """Get the current session data wrapper.
+
+        Returns:
+            SessionData object or None if no session exists
+
+        """
+        session_id = current_session_id.get()
+        if not session_id:
+            return None
+        data = self.session_store.get_session(session_id)
+        return SessionData(data) if data is not None else None
+
+    def set_session(self, data: Dict[str, Any]) -> bool:
+        """Set the entire session data.
+
+        Args:
+            data: New session data
+
+        Returns:
+            True if successful, False if no session exists
+
+        """
+        session_id = current_session_id.get()
+        if not session_id:
+            return False
+        return self.session_store.update_session(session_id, data)
+
+    def update_session(self, updater_func: Callable[[SessionData], None]) -> bool:
+        """Update session data using a function.
+
+        Args:
+            updater_func: Function that takes SessionData and updates it in place
+
+        Returns:
+            True if successful, False if no session exists
+
+        """
+        session = self.get_session()
+        if not session:
+            return False
+
+        # Update the session data
+        updater_func(session)
+
+        # Save back to storage
+        return self.set_session(session.raw())
+
+    def tool(self):
+        """Create a decorator for a function as an MCP tool.
+
+        Uses function name, docstring, and type hints to generate the MCP tool schema.
+        """
+
+        def decorator(func: Callable):
+            # Get function name and convert to camelCase for tool name
+            func_name = func.__name__
+            tool_name = ''.join(
+                [func_name.split('_')[0]]
+                + [word.capitalize() for word in func_name.split('_')[1:]]
+            )
+            lowered_tool_name = tool_name.lower()
+
+            # Get docstring and parse into description
+            doc = inspect.getdoc(func) or ''
+            description = doc.split('\n\n')[0]  # First paragraph is description
+
+            # Get type hints
+            hints = get_type_hints(func)
+            # return_type = hints.pop('return', Any)
+            hints.pop('return', Any)
+
+            # Build input schema from type hints and docstring
+            properties = {}
+            required = []
+
+            # Parse docstring for argument descriptions
+            arg_descriptions = {}
+            if doc:
+                lines = doc.split('\n')
+                in_args = False
+                for line in lines:
+                    if line.strip().startswith('Args:'):
+                        in_args = True
+                        continue
+                    if in_args:
+                        if not line.strip() or line.strip().startswith('Returns:'):
+                            break
+                        if ':' in line:
+                            arg_name, arg_desc = line.split(':', 1)
+                            arg_descriptions[arg_name.strip()] = arg_desc.strip()
+
+            def get_type_schema(type_hint: Any) -> Dict[str, Any]:
+                # Handle basic types
+                if type_hint is int:
+                    return {'type': 'integer'}
+                elif type_hint is float:
+                    return {'type': 'number'}
+                elif type_hint is bool:
+                    return {'type': 'boolean'}
+                elif type_hint is str:
+                    return {'type': 'string'}
+
+                # Handle Enums
+                if isinstance(type_hint, type) and issubclass(type_hint, Enum):
+                    return {'type': 'string', 'enum': [e.value for e in type_hint]}
+
+                # Get origin type (e.g., Dict from Dict[str, int])
+                origin = get_origin(type_hint)
+                if origin is None:
+                    return {'type': 'string'}  # Default for unknown types
+
+                # Handle Optional/Union[T, None]
+                if origin is Union:
+                    args = [arg for arg in get_args(type_hint) if arg is not type(None)]
+                    if len(args) == 1:
+                        return get_type_schema(args[0])
+                    # Fallback for complex unions
+                    return {'type': 'string'}
+
+                # Handle Dict types
+                if origin is dict or origin is Dict:
+                    args = get_args(type_hint)
+                    if not args:
+                        return {'type': 'object', 'additionalProperties': True}
+
+                    # Get value type schema (args[1] is value type)
+                    value_schema = get_type_schema(args[1])
+                    return {'type': 'object', 'additionalProperties': value_schema}
+
+                # Handle List types
+                if origin is list or origin is List:
+                    args = get_args(type_hint)
+                    if not args:
+                        return {'type': 'array', 'items': {}}
+
+                    item_schema = get_type_schema(args[0])
+                    return {'type': 'array', 'items': item_schema}
+
+                # Default for unknown complex types
+                return {'type': 'string'}
+
+            def is_mcp_context_param(param_name: str, param_type: Any) -> bool:
+                """Return True when the param is FastMCP context and should stay internal."""
+                if param_name != 'ctx':
+                    return False
+                type_name = getattr(param_type, '__name__', '')
+                return type_name == 'Context'
+
+            def is_read_only_tool_name(name: str) -> bool:
+                """Best-effort read-only classification for MCP clients."""
+                read_only_prefixes = (
+                    'list',
+                    'get',
+                    'search',
+                    'count',
+                    'check',
+                    'validate',
+                    'discover',
+                    'analyze',
+                    'diagnose',
+                    'lint',
+                )
+                return name.startswith(read_only_prefixes)
+
+            # Build properties from type hints
+            signature = inspect.signature(func)
+            for param_name, param_type in hints.items():
+                if is_mcp_context_param(param_name, param_type):
+                    continue
+
+                param_schema = get_type_schema(param_type)
+
+                if param_name in arg_descriptions:
+                    param_schema['description'] = arg_descriptions[param_name]
+
+                properties[param_name] = param_schema
+                # Only mark as required when there is no default value.
+                param = signature.parameters.get(param_name)
+                if param is not None:
+                    if param.default is inspect._empty:
+                        required.append(param_name)
+                    elif isinstance(param.default, FieldInfo) and param.default.is_required():
+                        required.append(param_name)
+
+            # Create tool schema
+            tool_schema = {
+                'name': tool_name,
+                'description': description,
+                'inputSchema': {'type': 'object', 'properties': properties, 'required': required},
+                'annotations': {'readOnlyHint': is_read_only_tool_name(lowered_tool_name)},
+            }
+
+            # Register the tool
+            self.tools[tool_name] = tool_schema
+            self.tool_implementations[tool_name] = func
+
+            @functools.wraps(func)
+            def wrapper(*args, **kwargs):
+                return func(*args, **kwargs)
+
+            return wrapper
+
+        return decorator
+
+    def _create_error_response(
+        self,
+        code: int,
+        message: str,
+        request_id: Optional[str] = None,
+        error_content: Optional[List[Dict]] = None,
+        session_id: Optional[str] = None,
+        status_code: Optional[int] = None,
+    ) -> Dict:
+        """Create a standardized error response."""
+        error = JSONRPCError(code=code, message=message)
+        response = JSONRPCResponse(
+            jsonrpc='2.0', id=request_id, error=error, errorContent=error_content
+        )
+
+        headers = {'Content-Type': 'application/json', 'MCP-Version': '0.6'}
+        if session_id:
+            headers['MCP-Session-Id'] = session_id
+
+        return {
+            'statusCode': status_code or self._error_code_to_http_status(code),
+            'body': response.model_dump_json(),
+            'headers': headers,
+        }
+
+    def _error_code_to_http_status(self, error_code: int) -> int:
+        """Map JSON-RPC error codes to HTTP status codes."""
+        error_map = {
+            -32700: 400,  # Parse error
+            -32600: 400,  # Invalid Request
+            -32601: 404,  # Method not found
+            -32602: 400,  # Invalid params
+            -32603: 500,  # Internal error
+        }
+        return error_map.get(error_code, 500)
+
+    def _create_success_response(
+        self, result: Any, request_id: str | None, session_id: Optional[str] = None
+    ) -> Dict:
+        """Create a standardized success response."""
+        response = JSONRPCResponse(jsonrpc='2.0', id=request_id, result=result)
+
+        headers = {'Content-Type': 'application/json', 'MCP-Version': '0.6'}
+        if session_id:
+            headers['MCP-Session-Id'] = session_id
+
+        return {'statusCode': 200, 'body': response.model_dump_json(), 'headers': headers}
+
+    def handle_request(self, event: Dict, context: Any) -> Dict:
+        """Handle an incoming Lambda request."""
+        request_id = None
+        session_id = None
+
+        try:
+            # Log the full event for debugging
+            logger.debug(f'Received event: {event}')
+
+            # Get headers (case-insensitive)
+            headers = {k.lower(): v for k, v in event.get('headers', {}).items()}
+
+            # Get session ID from headers if present
+            session_id = headers.get('mcp-session-id')
+
+            # Set current session ID in context
+            if session_id:
+                current_session_id.set(session_id)
+            else:
+                current_session_id.set(None)
+
+            # Check HTTP method for session deletion
+            if event.get('httpMethod') == 'DELETE' and session_id:
+                if self.session_store.delete_session(session_id):
+                    return {'statusCode': 204}
+                else:
+                    return {'statusCode': 404}
+
+            # Validate content type
+            if headers.get('content-type') != 'application/json':
+                return self._create_error_response(-32700, 'Unsupported Media Type')
+
+            try:
+                body = json.loads(event['body'])
+                logger.debug(f'Parsed request body: {body}')
+                request_id = body.get('id') if isinstance(body, dict) else None
+
+                # Check if this is a notification (no id field)
+                if isinstance(body, dict) and 'id' not in body:
+                    logger.debug('Request is a notification')
+                    return {
+                        'statusCode': 202,
+                        'body': '',
+                        'headers': {'Content-Type': 'application/json', 'MCP-Version': '0.6'},
+                    }
+
+                # Validate basic JSON-RPC structure
+                if (
+                    not isinstance(body, dict)
+                    or body.get('jsonrpc') != '2.0'
+                    or 'method' not in body
+                ):
+                    return self._create_error_response(-32700, 'Parse error', request_id)
+
+            except json.JSONDecodeError:
+                return self._create_error_response(-32700, 'Parse error')
+
+            # Parse and validate the request
+            request = JSONRPCRequest.model_validate(body)
+            logger.debug(f'Validated request: {request}')
+
+            # Handle initialization request
+            if request.method == 'initialize':
+                logger.info('Handling initialize request')
+                # Create new session
+                session_id = self.session_store.create_session()
+                current_session_id.set(session_id)
+                result = InitializeResult(
+                    protocolVersion='2024-11-05',
+                    serverInfo=ServerInfo(name=self.name, version=self.version),
+                    capabilities=Capabilities(tools={'list': True, 'call': True}),
+                )
+                return self._create_success_response(result.model_dump(), request.id, session_id)
+
+            # For all other requests, validate session if provided
+            if session_id:
+                session_data = self.session_store.get_session(session_id)
+                if session_data is None:
+                    return self._create_error_response(
+                        -32000, 'Invalid or expired session', request.id, status_code=404
+                    )
+            elif request.method != 'initialize' and not isinstance(
+                self.session_store, NoOpSessionStore
+            ):
+                return self._create_error_response(
+                    -32000, 'Session required', request.id, status_code=400
+                )
+
+            # Handle tools/list request
+            if request.method == 'tools/list':
+                logger.info('Handling tools/list request')
+                return self._create_success_response(
+                    {'tools': list(self.tools.values())}, request.id, session_id
+                )
+
+            # Handle tool calls
+            if request.method == 'tools/call' and request.params:
+                tool_name = request.params.get('name')
+                tool_args = request.params.get('arguments', {})
+
+                if tool_name not in self.tools:
+                    return self._create_error_response(
+                        -32601, f"Tool '{tool_name}' not found", request.id, session_id=session_id
+                    )
+
+                try:
+                    # Convert enum string values to enum objects
+                    converted_args = {}
+                    tool_func = self.tool_implementations[tool_name]
+                    hints = get_type_hints(tool_func)
+                    signature = inspect.signature(tool_func)
+
+                    for arg_name, arg_value in tool_args.items():
+                        arg_type = hints.get(arg_name)
+                        if isinstance(arg_type, type) and issubclass(arg_type, Enum):
+                            converted_args[arg_name] = arg_type(arg_value)
+                        else:
+                            converted_args[arg_name] = arg_value
+
+                    # Internal FastMCP context is not provided by JSON-RPC callers.
+                    if 'ctx' in signature.parameters and 'ctx' not in converted_args:
+                        converted_args['ctx'] = None
+
+                    # Unwrap Pydantic Field defaults so call sites get plain values.
+                    for param_name, param in signature.parameters.items():
+                        if param_name in converted_args:
+                            continue
+                        if isinstance(param.default, FieldInfo):
+                            if param.default.default_factory is not None:
+                                converted_args[param_name] = param.default.default_factory()
+                            elif param.default.default is not PydanticUndefined:
+                                converted_args[param_name] = param.default.default
+
+                    result = tool_func(**converted_args)
+                    if inspect.isawaitable(result):
+                        result = asyncio.run(result)
+                    content = [TextContent(text=str(result)).model_dump()]
+                    return self._create_success_response(
+                        {'content': content}, request.id, session_id
+                    )
+                except Exception as e:
+                    logger.error(f'Error executing tool {tool_name}: {e}')
+                    error_content = [ErrorContent(text=str(e)).model_dump()]
+                    return self._create_error_response(
+                        -32603,
+                        f'Error executing tool: {str(e)}',
+                        request.id,
+                        error_content,
+                        session_id,
+                    )
+
+            # Handle pings
+            if request.method == 'ping':
+                return self._create_success_response({}, request.id, session_id)
+
+            # Handle unknown methods
+            return self._create_error_response(
+                -32601, f'Method not found: {request.method}', request.id, session_id=session_id
+            )
+
+        except Exception as e:
+            logger.error(f'Error processing request: {str(e)}', exc_info=True)
+            return self._create_error_response(-32000, str(e), request_id, session_id=session_id)
+        finally:
+            # Clear session context
+            current_session_id.set(None)

--- a/src/cloudwatch-mcp-server/awslabs/mcp_lambda_handler/session.py
+++ b/src/cloudwatch-mcp-server/awslabs/mcp_lambda_handler/session.py
@@ -1,0 +1,215 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Session management for MCP server with pluggable storage."""
+
+import boto3
+import logging
+import time
+import uuid
+from abc import ABC, abstractmethod
+from typing import Any, Dict, Optional
+
+
+logger = logging.getLogger(__name__)
+
+
+class SessionStore(ABC):
+    """Abstract base class for session storage implementations."""
+
+    @abstractmethod
+    def create_session(self, session_data: Optional[Dict[str, Any]] = None) -> str:
+        """Create a new session.
+
+        Args:
+            session_data: Optional initial session data
+
+        Returns:
+            The session ID
+
+        """
+        pass
+
+    @abstractmethod
+    def get_session(self, session_id: str) -> Optional[Dict[str, Any]]:
+        """Get session data.
+
+        Args:
+            session_id: The session ID to look up
+
+        Returns:
+            Session data or None if not found
+
+        """
+        pass
+
+    @abstractmethod
+    def update_session(self, session_id: str, session_data: Dict[str, Any]) -> bool:
+        """Update session data.
+
+        Args:
+            session_id: The session ID to update
+            session_data: New session data
+
+        Returns:
+            True if successful, False otherwise
+
+        """
+        pass
+
+    @abstractmethod
+    def delete_session(self, session_id: str) -> bool:
+        """Delete a session.
+
+        Args:
+            session_id: The session ID to delete
+
+        Returns:
+            True if successful, False otherwise
+
+        """
+        pass
+
+
+class NoOpSessionStore(SessionStore):
+    """A no-op session store that doesn't actually store sessions."""
+
+    def create_session(self, session_data: Optional[Dict[str, Any]] = None) -> str:
+        """Create a new session ID but don't store anything."""
+        return str(uuid.uuid4())
+
+    def get_session(self, session_id: str) -> Optional[Dict[str, Any]]:
+        """Return an empty session data."""
+        return {}
+
+    def update_session(self, session_id: str, session_data: Dict[str, Any]) -> bool:
+        """Pretend to update but do nothing."""
+        return True
+
+    def delete_session(self, session_id: str) -> bool:
+        """Pretend to delete but do nothing."""
+        return True
+
+
+class DynamoDBSessionStore(SessionStore):
+    """Manages MCP sessions using DynamoDB."""
+
+    def __init__(self, table_name: str = 'mcp_sessions'):
+        """Initialize the session store.
+
+        Args:
+            table_name: Name of DynamoDB table to use for sessions
+
+        """
+        self.table_name = table_name
+        self.dynamodb = boto3.resource('dynamodb')
+        self.table = self.dynamodb.Table(table_name)  # pyright: ignore [reportAttributeAccessIssue]
+
+    def create_session(self, session_data: Optional[Dict[str, Any]] = None) -> str:
+        """Create a new session.
+
+        Args:
+            session_data: Optional initial session data
+
+        Returns:
+            The session ID
+
+        """
+        # Generate a secure random UUID for the session
+        session_id = str(uuid.uuid4())
+
+        # Set session expiry to 24 hours from now
+        expires_at = int(time.time()) + (24 * 60 * 60)
+
+        # Store session in DynamoDB
+        item = {
+            'session_id': session_id,
+            'expires_at': expires_at,
+            'created_at': int(time.time()),
+            'data': session_data or {},
+        }
+
+        self.table.put_item(Item=item)
+        logger.info(f'Created session {session_id}')
+
+        return session_id
+
+    def get_session(self, session_id: str) -> Optional[Dict[str, Any]]:
+        """Get session data.
+
+        Args:
+            session_id: The session ID to look up
+
+        Returns:
+            Session data or None if not found
+
+        """
+        try:
+            response = self.table.get_item(Key={'session_id': session_id})
+            item = response.get('Item')
+
+            if not item:
+                return None
+
+            # Check if session has expired
+            if item.get('expires_at', 0) < time.time():
+                self.delete_session(session_id)
+                return None
+
+            return item.get('data', {})
+
+        except Exception as e:
+            logger.error(f'Error getting session {session_id}: {e}')
+            return None
+
+    def update_session(self, session_id: str, session_data: Dict[str, Any]) -> bool:
+        """Update session data.
+
+        Args:
+            session_id: The session ID to update
+            session_data: New session data
+
+        Returns:
+            True if successful, False otherwise
+
+        """
+        try:
+            self.table.update_item(
+                Key={'session_id': session_id},
+                UpdateExpression='SET #data = :data',
+                ExpressionAttributeNames={'#data': 'data'},
+                ExpressionAttributeValues={':data': session_data},
+            )
+            return True
+        except Exception as e:
+            logger.error(f'Error updating session {session_id}: {e}')
+            return False
+
+    def delete_session(self, session_id: str) -> bool:
+        """Delete a session.
+
+        Args:
+            session_id: The session ID to delete
+
+        Returns:
+            True if successful, False otherwise
+
+        """
+        try:
+            self.table.delete_item(Key={'session_id': session_id})
+            logger.info(f'Deleted session {session_id}')
+            return True
+        except Exception as e:
+            logger.error(f'Error deleting session {session_id}: {e}')
+            return False

--- a/src/cloudwatch-mcp-server/awslabs/mcp_lambda_handler/types.py
+++ b/src/cloudwatch-mcp-server/awslabs/mcp_lambda_handler/types.py
@@ -1,0 +1,153 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Type definitions for MCP protocol."""
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class JSONRPCError:
+    code: int
+    message: str
+    data: Optional[Any] = None
+
+    def model_dump_json(self) -> str:
+        import json
+
+        return json.dumps(
+            {
+                'code': self.code,
+                'message': self.message,
+                **({'data': self.data} if self.data is not None else {}),
+            }
+        )
+
+
+@dataclass
+class JSONRPCResponse:
+    jsonrpc: str
+    id: Optional[str]
+    result: Optional[Any] = None
+    error: Optional[JSONRPCError] = None
+    errorContent: Optional[List[Dict]] = None
+
+    def model_dump_json(self) -> str:
+        import json
+
+        data = {'jsonrpc': self.jsonrpc, 'id': self.id}
+        if self.result is not None:
+            data['result'] = self.result
+        if self.error is not None:
+            data['error'] = json.loads(self.error.model_dump_json())
+        if self.errorContent is not None:
+            data['errorContent'] = self.errorContent
+        return json.dumps(data)
+
+
+@dataclass
+class ServerInfo:
+    name: str
+    version: str
+
+    def model_dump(self) -> Dict:
+        return {'name': self.name, 'version': self.version}
+
+
+@dataclass
+class Capabilities:
+    tools: Dict[str, bool]
+
+    def model_dump(self) -> Dict:
+        return {'tools': self.tools}
+
+
+@dataclass
+class InitializeResult:
+    protocolVersion: str
+    serverInfo: ServerInfo
+    capabilities: Capabilities
+
+    def model_dump(self) -> Dict:
+        return {
+            'protocolVersion': self.protocolVersion,
+            'serverInfo': self.serverInfo.model_dump(),
+            'capabilities': self.capabilities.model_dump(),
+        }
+
+    def model_dump_json(self) -> str:
+        import json
+
+        return json.dumps(self.model_dump())
+
+
+@dataclass
+class JSONRPCRequest:
+    jsonrpc: str
+    id: Optional[str]
+    method: str
+    params: Optional[Dict] = None
+
+    @classmethod
+    def model_validate(cls, data: Dict) -> 'JSONRPCRequest':
+        return cls(
+            jsonrpc=data['jsonrpc'],
+            id=data.get('id'),
+            method=data['method'],
+            params=data.get('params'),
+        )
+
+
+@dataclass
+class TextContent:
+    text: str
+    type: str = 'text'
+
+    def model_dump(self) -> Dict:
+        return {'type': self.type, 'text': self.text}
+
+    def model_dump_json(self) -> str:
+        import json
+
+        return json.dumps(self.model_dump())
+
+
+@dataclass
+class ErrorContent:
+    text: str
+    type: str = 'error'
+
+    def model_dump(self) -> Dict:
+        return {'type': self.type, 'text': self.text}
+
+    def model_dump_json(self) -> str:
+        import json
+
+        return json.dumps(self.model_dump())
+
+
+@dataclass
+class ImageContent:
+    data: str
+    mimeType: str
+    type: str = 'image'
+
+    def model_dump(self) -> Dict:
+        return {'type': self.type, 'data': self.data, 'mimeType': self.mimeType}
+
+    def model_dump_json(self) -> str:
+        import json
+
+        return json.dumps(self.model_dump())

--- a/src/cloudwatch-mcp-server/tests/test_lambda_handler.py
+++ b/src/cloudwatch-mcp-server/tests/test_lambda_handler.py
@@ -1,0 +1,86 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for CloudWatch Lambda handler endpoints and MCP surface."""
+
+import json
+
+from awslabs.cloudwatch_mcp_server.lambda_handler import lambda_handler
+
+
+def test_oauth_well_known_endpoint_returns_metadata(monkeypatch):
+    """The OAuth well-known endpoint should return authorization server metadata."""
+    monkeypatch.setenv('OAUTH_CLIENT_ID', 'test-client-id')
+
+    event = {
+        'rawPath': '/.well-known/oauth-authorization-server',
+        'requestContext': {
+            'domainName': 'abc123.execute-api.eu-west-1.amazonaws.com',
+            'stage': 'stable',
+        },
+    }
+
+    response = lambda_handler(event, None)
+
+    assert response['statusCode'] == 200
+    body = json.loads(response['body'])
+    assert body['issuer'].startswith('https://')
+    assert body['registration_endpoint'] == (
+        'https://abc123.execute-api.eu-west-1.amazonaws.com/stable/register'
+    )
+
+
+def test_dynamic_client_registration_returns_preregistered_client(monkeypatch):
+    """The /register endpoint should return pre-registered client metadata."""
+    monkeypatch.setenv('OAUTH_CLIENT_ID', 'client-123')
+
+    event = {
+        'rawPath': '/register',
+        'requestContext': {'http': {'method': 'POST'}},
+        'body': json.dumps({'client_name': 'ChatGPT CloudWatch', 'redirect_uris': ['https://a.b/c']}),
+    }
+
+    response = lambda_handler(event, None)
+
+    assert response['statusCode'] == 201
+    body = json.loads(response['body'])
+    assert body['client_id'] == 'client-123'
+    assert body['client_name'] == 'ChatGPT CloudWatch'
+    assert body['redirect_uris'] == ['https://a.b/c']
+
+
+def test_tools_list_includes_cloudwatch_tools():
+    """tools/list should expose registered CloudWatch tools through JSON-RPC."""
+    event = {
+        'httpMethod': 'POST',
+        'headers': {'content-type': 'application/json'},
+        'body': json.dumps(
+            {
+                'jsonrpc': '2.0',
+                'id': 'req-1',
+                'method': 'tools/list',
+                'params': {},
+            }
+        ),
+    }
+
+    response = lambda_handler(event, None)
+
+    assert response['statusCode'] == 200
+    payload = json.loads(response['body'])
+    tool_names = {tool['name'] for tool in payload['result']['tools']}
+
+    assert 'describeLogGroups' in tool_names
+    assert 'getMetricData' in tool_names
+    assert 'getActiveAlarms' in tool_names


### PR DESCRIPTION
## Summary\n- add a Lambda entrypoint for CloudWatch MCP using MCPLambdaHandler\n- expose OAuth discovery endpoints and dynamic client registration endpoint for ChatGPT connector flows\n- register CloudWatch logs/metrics/alarms tools for JSON-RPC MCP calls\n- switch cloudwatch-mcp-server Dockerfile to Lambda runtime image with Lambda handler command\n- add Lambda handler tests for well-known metadata, /register, and tools/list\n\n## Issues\n- Refs #21\n- Refs #22\n\n## Validation\n- uv run pytest tests/test_lambda_handler.py tests/test_main.py