### PR TITLE
cloudwatch-mcp-server: add API Gateway and Cognito deployment templates

### DIFF
--- a/src/cloudwatch-mcp-server/README.md
+++ b/src/cloudwatch-mcp-server/README.md
@@ -128,6 +128,13 @@ Please reference [AWS documentation](https://docs.aws.amazon.com/cli/v1/userguid
 
 Contributions are welcome! Please see the [CONTRIBUTING.md](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md) in the monorepo root for guidelines.
 
+## Lambda/API Gateway Deployment Artifacts
+
+The `deploy/` folder contains CloudFormation templates for deploying this server behind API Gateway with Cognito OAuth for ChatGPT connector flows:
+
+- `deploy/cloudwatch-mcp-http-api.yaml` configures HTTP API routes, JWT authorizer, CORS, stage settings, and Lambda integration
+- `deploy/cloudwatch-mcp-cognito-app-client.yaml` configures a Cognito User Pool app client with authorization code + PKCE settings, ChatGPT callback URL, and API callback/logout URLs
+
 ## Feedback and Issues
 
 We value your feedback! Submit your feedback, feature requests and any bugs at [GitHub issues](https://github.com/awslabs/mcp/issues) with prefix `cloudwatch-mcp-server` in title.

--- a/src/cloudwatch-mcp-server/deploy/cloudwatch-mcp-cognito-app-client.yaml
+++ b/src/cloudwatch-mcp-server/deploy/cloudwatch-mcp-cognito-app-client.yaml
@@ -1,0 +1,51 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Cognito app client for CloudWatch MCP ChatGPT connector.
+
+Parameters:
+  UserPoolId:
+    Type: String
+    Description: Cognito User Pool ID used by the CloudWatch MCP API JWT authorizer.
+  AppClientName:
+    Type: String
+    Default: cloudwatch-mcp-chatgpt-app-client
+  HostedUiDomain:
+    Type: String
+    Description: Cognito Hosted UI domain prefix (for example my-domain-prefix).
+  CallbackApiBaseUrl:
+    Type: String
+    Description: API base URL including stage (for example https://<api-id>.execute-api.<region>.amazonaws.com/stable).
+
+Resources:
+  CloudWatchMcpUserPoolClient:
+    Type: AWS::Cognito::UserPoolClient
+    Properties:
+      UserPoolId: !Ref UserPoolId
+      ClientName: !Ref AppClientName
+      GenerateSecret: false
+      AllowedOAuthFlowsUserPoolClient: true
+      AllowedOAuthFlows:
+        - code
+      AllowedOAuthScopes:
+        - openid
+        - profile
+        - email
+      SupportedIdentityProviders:
+        - COGNITO
+      CallbackURLs:
+        - https://chatgpt.com/connector_platform_oauth_redirect
+        - !Sub ${CallbackApiBaseUrl}/callback
+      LogoutURLs:
+        - !Sub ${CallbackApiBaseUrl}/logout
+      ExplicitAuthFlows:
+        - ALLOW_USER_SRP_AUTH
+        - ALLOW_REFRESH_TOKEN_AUTH
+
+Outputs:
+  UserPoolClientId:
+    Value: !Ref CloudWatchMcpUserPoolClient
+  IssuerUrl:
+    Value: !Sub https://cognito-idp.${AWS::Region}.amazonaws.com/${UserPoolId}
+  AuthorizationEndpoint:
+    Value: !Sub https://${HostedUiDomain}.auth.${AWS::Region}.amazoncognito.com/oauth2/authorize
+  TokenEndpoint:
+    Value: !Sub https://${HostedUiDomain}.auth.${AWS::Region}.amazoncognito.com/oauth2/token

--- a/src/cloudwatch-mcp-server/deploy/cloudwatch-mcp-http-api.yaml
+++ b/src/cloudwatch-mcp-server/deploy/cloudwatch-mcp-http-api.yaml
@@ -1,0 +1,161 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: API Gateway HTTP API and JWT authorizer for CloudWatch MCP Lambda.
+
+Parameters:
+  ApiName:
+    Type: String
+    Default: cloudwatch-mcp-api
+  StageName:
+    Type: String
+    Default: stable
+  LambdaFunctionArn:
+    Type: String
+    Description: ARN of the CloudWatch MCP Lambda function.
+  JwtIssuer:
+    Type: String
+    Description: Cognito issuer URL (for example https://cognito-idp.eu-west-1.amazonaws.com/<pool-id>).
+  JwtAudience:
+    Type: String
+    Description: Cognito app client ID used by ChatGPT connector.
+  AccessLogGroupArn:
+    Type: String
+    Description: ARN of an existing CloudWatch Logs log group for API Gateway access logs.
+
+Resources:
+  CloudWatchMcpApi:
+    Type: AWS::ApiGatewayV2::Api
+    Properties:
+      Name: !Ref ApiName
+      ProtocolType: HTTP
+      CorsConfiguration:
+        AllowMethods:
+          - GET
+          - POST
+          - OPTIONS
+        AllowOrigins:
+          - '*'
+        AllowHeaders:
+          - Authorization
+          - Content-Type
+          - MCP-Session-Id
+
+  CloudWatchMcpIntegration:
+    Type: AWS::ApiGatewayV2::Integration
+    Properties:
+      ApiId: !Ref CloudWatchMcpApi
+      IntegrationType: AWS_PROXY
+      IntegrationMethod: POST
+      IntegrationUri: !Sub >-
+        arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${LambdaFunctionArn}/invocations
+      PayloadFormatVersion: '2.0'
+      TimeoutInMillis: 30000
+
+  CognitoJwtAuthorizer:
+    Type: AWS::ApiGatewayV2::Authorizer
+    Properties:
+      ApiId: !Ref CloudWatchMcpApi
+      Name: cognito_jwt
+      AuthorizerType: JWT
+      IdentitySource:
+        - $request.header.Authorization
+      JwtConfiguration:
+        Issuer: !Ref JwtIssuer
+        Audience:
+          - !Ref JwtAudience
+
+  ProtectedRootRoute:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !Ref CloudWatchMcpApi
+      RouteKey: ANY /
+      AuthorizationType: JWT
+      AuthorizerId: !Ref CognitoJwtAuthorizer
+      Target: !Sub integrations/${CloudWatchMcpIntegration}
+
+  ProtectedProxyRoute:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !Ref CloudWatchMcpApi
+      RouteKey: ANY /{proxy+}
+      AuthorizationType: JWT
+      AuthorizerId: !Ref CognitoJwtAuthorizer
+      Target: !Sub integrations/${CloudWatchMcpIntegration}
+
+  OAuthWellKnownOpenIdRoute:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !Ref CloudWatchMcpApi
+      RouteKey: GET /.well-known/openid-configuration
+      AuthorizationType: NONE
+      Target: !Sub integrations/${CloudWatchMcpIntegration}
+
+  OAuthWellKnownAuthorizationServerRoute:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !Ref CloudWatchMcpApi
+      RouteKey: GET /.well-known/oauth-authorization-server
+      AuthorizationType: NONE
+      Target: !Sub integrations/${CloudWatchMcpIntegration}
+
+  OAuthWellKnownProxyRoute:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !Ref CloudWatchMcpApi
+      RouteKey: GET /.well-known/{proxy+}
+      AuthorizationType: NONE
+      Target: !Sub integrations/${CloudWatchMcpIntegration}
+
+  RegisterRoute:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !Ref CloudWatchMcpApi
+      RouteKey: POST /register
+      AuthorizationType: NONE
+      Target: !Sub integrations/${CloudWatchMcpIntegration}
+
+  CallbackRoute:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !Ref CloudWatchMcpApi
+      RouteKey: ANY /callback
+      AuthorizationType: NONE
+      Target: !Sub integrations/${CloudWatchMcpIntegration}
+
+  LogoutRoute:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !Ref CloudWatchMcpApi
+      RouteKey: ANY /logout
+      AuthorizationType: NONE
+      Target: !Sub integrations/${CloudWatchMcpIntegration}
+
+  CloudWatchMcpStage:
+    Type: AWS::ApiGatewayV2::Stage
+    Properties:
+      ApiId: !Ref CloudWatchMcpApi
+      StageName: !Ref StageName
+      AutoDeploy: true
+      DefaultRouteSettings:
+        DetailedMetricsEnabled: true
+        ThrottlingBurstLimit: 500
+        ThrottlingRateLimit: 1000
+      AccessLogSettings:
+        DestinationArn: !Ref AccessLogGroupArn
+        Format: >-
+          {"requestId":"$context.requestId","ip":"$context.identity.sourceIp","requestTime":"$context.requestTime","httpMethod":"$context.httpMethod","routeKey":"$context.routeKey","status":"$context.status","protocol":"$context.protocol","responseLength":"$context.responseLength"}
+
+  AllowApiGatewayInvokeLambda:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !Ref LambdaFunctionArn
+      Principal: apigateway.amazonaws.com
+      SourceArn: !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${CloudWatchMcpApi}/*/*/*
+
+Outputs:
+  ApiId:
+    Value: !Ref CloudWatchMcpApi
+  ApiEndpoint:
+    Value: !GetAtt CloudWatchMcpApi.ApiEndpoint
+  StageInvokeUrl:
+    Value: !Sub ${CloudWatchMcpApi.ApiEndpoint}/${StageName}


### PR DESCRIPTION
## Summary\n- add CloudFormation template for API Gateway HTTP API, Lambda proxy integration, JWT authorizer, and route auth model\n- add CloudFormation template for Cognito app client settings required by ChatGPT connector OAuth\n- document these deployment artifacts in the CloudWatch MCP README\n\n## Issues\n- Refs #19\n- Refs #23\n\n## Notes\n- This PR is stacked on top of #24 to keep cumulative changes conflict-free while both are open.\n- After #24 merges, retarget this PR to main.\n\n## Validation\n- uv run pytest tests/test_lambda_handler.py tests/test_main.py