### PR TITLE
Healthomics: define Healthomics-CloudWatch boundary

### DIFF
--- a/src/aws-healthomics-mcp-server/DEPLOYMENT.md
+++ b/src/aws-healthomics-mcp-server/DEPLOYMENT.md
@@ -5,6 +5,11 @@
 This guide covers how to deploy workflow definitions to AWS HealthOmics using the
 `aws-healthomics-mcp-server` tools.
 
+Architecture note:
+See [docs/healthomics-cloudwatch-boundary.md](docs/healthomics-cloudwatch-boundary.md) for
+the decision on workflow-native user interfaces and internal HealthOmics+CloudWatch
+orchestration.
+
 ## What "deployment" means here
 
 For this server, deployment typically means:

--- a/src/aws-healthomics-mcp-server/README.md
+++ b/src/aws-healthomics-mcp-server/README.md
@@ -3,6 +3,8 @@
 A Model Context Protocol (MCP) server that provides AI assistants with comprehensive access to AWS HealthOmics services for genomic workflow management, execution, and analysis.
 
 For workflow deployment steps, see [DEPLOYMENT.md](DEPLOYMENT.md).
+For the Healthomics/CloudWatch architecture boundary, see
+[docs/healthomics-cloudwatch-boundary.md](docs/healthomics-cloudwatch-boundary.md).
 
 ## Overview
 
@@ -26,6 +28,8 @@ This MCP server provides tools for:
 - **Performance analysis**: Analyze workflow execution performance and resource utilization
 - **Failure diagnosis**: Comprehensive troubleshooting tools for failed workflow runs
 - **Log access**: Retrieve detailed logs from runs, engines, tasks, and manifests
+- **Hybrid monitoring model**: Workflow-native interfaces in this server, with CloudWatch details
+  resolved internally for users when needed
 
 ### 🌍 Region Management
 - **Multi-region support**: Get information about AWS regions where HealthOmics is available

--- a/src/aws-healthomics-mcp-server/docs/healthomics-cloudwatch-boundary.md
+++ b/src/aws-healthomics-mcp-server/docs/healthomics-cloudwatch-boundary.md
@@ -1,0 +1,44 @@
+# Healthomics-CloudWatch Boundary
+
+## Decision
+
+Use a workflow-native interface in `aws-healthomics-mcp-server` and keep CloudWatch details hidden
+from normal users.
+
+Use `cloudwatch-mcp-server` for advanced/operator log-native operations.
+
+## Why
+
+- HealthOmics APIs provide coarse lifecycle and task state.
+- Detailed execution progress is often only visible in CloudWatch task/engine logs.
+- Users should not need to know CloudWatch log group/stream names to monitor workflows.
+- Separation keeps IAM scope tighter and avoids coupling deployment of both servers.
+
+## Responsibilities
+
+### aws-healthomics-mcp-server
+
+- Primary user-facing workflow interface.
+- Run/task lifecycle operations.
+- Server-side orchestration of HealthOmics metadata and CloudWatch-derived detail where required.
+- Stable workflow-centric contracts (`run_id`, `task_id`) without exposing CloudWatch identifiers.
+
+### cloudwatch-mcp-server
+
+- Advanced log retrieval and log analytics.
+- Generic log exploration and ad-hoc querying.
+- Operator-focused debugging workflows.
+
+## User Experience Rules
+
+- Standard monitoring tools must accept workflow-native inputs only.
+- The server must internally resolve any log destinations.
+- If detailed logs are missing, tools must degrade to coarse HealthOmics status and state this clearly.
+
+## Implementation sequence
+
+1. Define and approve this boundary.
+2. Define structured workflow event schema and taxonomy.
+3. Implement task-log tailing and run-summary aggregation using internal orchestration.
+4. Add hybrid progress reporting with explicit confidence/fallback modes.
+


### PR DESCRIPTION
## Summary
- add a dedicated architecture decision doc for the Healthomics/CloudWatch boundary
- define user-facing rule: workflow-native interfaces only; no CloudWatch identifiers required from users
- clarify server responsibilities and implementation sequence for follow-on issues (#27/#28/#26)
- link the boundary doc from README and deployment guide

## Files
- `src/aws-healthomics-mcp-server/docs/healthomics-cloudwatch-boundary.md`
- `src/aws-healthomics-mcp-server/README.md`
- `src/aws-healthomics-mcp-server/DEPLOYMENT.md`

## Validation
- docs-only change; no runtime code modified
