### PR TITLE
Healthomics: add TailAHORunTaskLogs tool

### DIFF
--- a/src/aws-healthomics-mcp-server/DEPLOYMENT.md
+++ b/src/aws-healthomics-mcp-server/DEPLOYMENT.md
@@ -115,6 +115,7 @@ Use:
 - `GetAHORunEngineLogs`
 - `GetAHORunManifestLogs`
 - `GetAHOTaskLogs`
+- `TailAHORunTaskLogs`
 - `DiagnoseAHORunFailure`
 - `AnalyzeAHORunPerformance`
 

--- a/src/aws-healthomics-mcp-server/README.md
+++ b/src/aws-healthomics-mcp-server/README.md
@@ -62,6 +62,7 @@ This MCP server provides tools for:
 4. **GetAHORunEngineLogs** - Retrieve workflow engine logs (STDOUT/STDERR) for debugging
 5. **GetAHORunManifestLogs** - Access run manifest logs with runtime information and metrics
 6. **GetAHOTaskLogs** - Get task-specific logs for debugging individual workflow steps
+7. **TailAHORunTaskLogs** - Tail merged recent task/run events without requiring CloudWatch identifiers
 
 ### Region Management Tools
 

--- a/src/aws-healthomics-mcp-server/awslabs/aws_healthomics_mcp_server/lambda_handler.py
+++ b/src/aws-healthomics-mcp-server/awslabs/aws_healthomics_mcp_server/lambda_handler.py
@@ -960,6 +960,45 @@ def GetAHOTaskLogs(
 
 
 @mcp.tool()
+def TailAHORunTaskLogs(
+    run_id: str,
+    task_id: Optional[str] = None,
+    limit: int = 100,
+    since_seconds: Optional[int] = None,
+    include_system_events: bool = True,
+) -> Dict[str, Any]:
+    """Tail recent task and run logs for a workflow run.
+
+    Args:
+        run_id: ID of the run
+        task_id: Optional specific task ID to tail
+        limit: Maximum number of merged events to return
+        since_seconds: Optional lookback window in seconds
+        include_system_events: Include high-level run events
+
+    Returns:
+        Dictionary containing merged recent events and diagnostics
+    """
+    from awslabs.aws_healthomics_mcp_server.tools.workflow_analysis import tail_run_task_logs
+
+    async def _call():
+        class MockContext:
+            async def error(self, msg):
+                logger.error(msg)
+
+        return await tail_run_task_logs(
+            MockContext(),
+            run_id=run_id,
+            task_id=task_id,
+            limit=limit,
+            since_seconds=since_seconds,
+            include_system_events=include_system_events,
+        )
+
+    return _run_async(_call())
+
+
+@mcp.tool()
 def AnalyzeAHORunPerformance(run_ids: Union[List[str], str]) -> str:
     """Analyze workflow run performance and provide optimization recommendations.
 

--- a/src/aws-healthomics-mcp-server/awslabs/aws_healthomics_mcp_server/server.py
+++ b/src/aws-healthomics-mcp-server/awslabs/aws_healthomics_mcp_server/server.py
@@ -86,6 +86,7 @@ from awslabs.aws_healthomics_mcp_server.tools.workflow_analysis import (
     get_run_logs,
     get_run_manifest_logs,
     get_task_logs,
+    tail_run_task_logs,
 )
 from awslabs.aws_healthomics_mcp_server.tools.workflow_execution import (
     cancel_run,
@@ -139,6 +140,7 @@ This MCP server provides tools for creating, managing, and analyzing genomic wor
 - **GetAHORunManifestLogs**: Retrieve run manifest logs with workflow summary
 - **GetAHORunEngineLogs**: Retrieve engine logs containing STDOUT and STDERR
 - **GetAHOTaskLogs**: Retrieve logs for specific workflow tasks
+- **TailAHORunTaskLogs**: Tail recent task/run logs for a workflow using run-native inputs
 - **AnalyzeAHORunPerformance**: Analyze workflow run performance and resource utilization to provide optimization recommendations
 - **GenerateAHORunTimeline**: Generate a Gantt-style SVG timeline visualization showing task execution phases and parallelism
 
@@ -246,6 +248,7 @@ mcp.tool(name='GetAHORunLogs')(get_run_logs)
 mcp.tool(name='GetAHORunManifestLogs')(get_run_manifest_logs)
 mcp.tool(name='GetAHORunEngineLogs')(get_run_engine_logs)
 mcp.tool(name='GetAHOTaskLogs')(get_task_logs)
+mcp.tool(name='TailAHORunTaskLogs')(tail_run_task_logs)
 mcp.tool(name='AnalyzeAHORunPerformance')(analyze_run_performance)
 mcp.tool(name='GenerateAHORunTimeline')(generate_run_timeline)
 

--- a/src/aws-healthomics-mcp-server/awslabs/aws_healthomics_mcp_server/tools/helper_tools.py
+++ b/src/aws-healthomics-mcp-server/awslabs/aws_healthomics_mcp_server/tools/helper_tools.py
@@ -83,6 +83,7 @@ Recommended sequence:
   - `GetAHORunManifestLogs`
   - `GetAHORunEngineLogs`
   - `GetAHOTaskLogs`
+  - `TailAHORunTaskLogs`
 - Use `DiagnoseAHORunFailure` for automated failure analysis.
 """,
 }

--- a/src/aws-healthomics-mcp-server/awslabs/aws_healthomics_mcp_server/tools/workflow_analysis.py
+++ b/src/aws-healthomics-mcp-server/awslabs/aws_healthomics_mcp_server/tools/workflow_analysis.py
@@ -14,14 +14,16 @@
 
 """Workflow analysis tools for the AWS HealthOmics MCP server."""
 
+from awslabs.aws_healthomics_mcp_server.utils.aws_utils import get_omics_client
 from awslabs.aws_healthomics_mcp_server.utils.aws_utils import get_logs_client
 from awslabs.aws_healthomics_mcp_server.utils.error_utils import handle_tool_error
 from botocore.exceptions import ClientError
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from loguru import logger
 from mcp.server.fastmcp import Context
 from pydantic import Field
-from typing import Any, Dict, Optional
+from pydantic.fields import FieldInfo
+from typing import Any, Dict, List, Optional
 
 
 async def _get_logs_from_stream(
@@ -534,3 +536,173 @@ async def get_task_logs_internal(
     except Exception as e:
         logger.error(f'Error retrieving task logs: {str(e)}')
         raise
+
+
+async def tail_run_task_logs(
+    ctx: Context,
+    run_id: str = Field(
+        ...,
+        description='ID of the run',
+    ),
+    task_id: Optional[str] = Field(
+        None,
+        description='Optional specific task ID to tail logs from',
+    ),
+    limit: int = Field(
+        100,
+        description='Maximum number of merged events to return',
+        ge=1,
+        le=1000,
+    ),
+    since_seconds: Optional[int] = Field(
+        None,
+        description='Optional lookback window in seconds from now',
+        ge=1,
+        le=86400,
+    ),
+    include_system_events: bool = Field(
+        True,
+        description='Whether to include high-level run events from run/{run_id} stream',
+    ),
+) -> Dict[str, Any]:
+    """Tail recent logs for active run tasks with workflow-native inputs.
+
+    The user provides only `run_id` (and optionally `task_id`). The server resolves
+    HealthOmics task metadata and CloudWatch stream names internally.
+    """
+    logs_client = get_logs_client()
+    omics_client = get_omics_client()
+    log_group_name = '/aws/omics/WorkflowLog'
+    if isinstance(task_id, FieldInfo):
+        task_id = None
+    if isinstance(limit, FieldInfo):
+        limit = 100
+    if isinstance(since_seconds, FieldInfo):
+        since_seconds = None
+    if isinstance(include_system_events, FieldInfo):
+        include_system_events = True
+
+    try:
+        run_response = omics_client.get_run(id=run_id)
+        run_status = run_response.get('status')
+        workflow_id = run_response.get('workflowId')
+
+        all_tasks: List[Dict[str, Any]] = []
+        next_token: Optional[str] = None
+        while True:
+            params: Dict[str, Any] = {'id': run_id, 'maxResults': 100}
+            if next_token:
+                params['startingToken'] = next_token
+            response = omics_client.list_run_tasks(**params)
+            all_tasks.extend(response.get('items', []))
+            next_token = response.get('nextToken')
+            if not next_token:
+                break
+
+        if task_id:
+            selected_tasks = [task for task in all_tasks if task.get('taskId') == task_id]
+            if not selected_tasks:
+                selected_tasks = [{'taskId': task_id, 'status': 'UNKNOWN', 'name': None}]
+        else:
+            active_statuses = {'PENDING', 'STARTING', 'RUNNING', 'STOPPING', 'CANCELLING'}
+            selected_tasks = [
+                task for task in all_tasks if str(task.get('status', '')).upper() in active_statuses
+            ]
+            if not selected_tasks and all_tasks:
+                def _task_sort_key(task: Dict[str, Any]) -> float:
+                    value = task.get('startTime') or task.get('creationTime')
+                    if isinstance(value, datetime):
+                        return value.timestamp()
+                    return 0.0
+
+                selected_tasks = sorted(
+                    all_tasks,
+                    key=_task_sort_key,
+                    reverse=True,
+                )[:1]
+
+        start_time: Optional[str] = None
+        if since_seconds:
+            start_time = (datetime.now(timezone.utc) - timedelta(seconds=since_seconds)).isoformat()
+
+        merged_events: List[Dict[str, Any]] = []
+        task_event_limit = max(10, min(limit, 250))
+
+        for task in selected_tasks:
+            selected_task_id = task.get('taskId')
+            if not selected_task_id:
+                continue
+
+            task_stream = f'run/{run_id}/task/{selected_task_id}'
+            try:
+                task_logs = await _get_logs_from_stream(
+                    logs_client,
+                    log_group_name,
+                    task_stream,
+                    start_time=start_time,
+                    limit=task_event_limit,
+                    start_from_head=False,
+                )
+                for event in task_logs.get('events', []):
+                    merged_events.append(
+                        {
+                            'timestamp': event.get('timestamp'),
+                            'taskId': selected_task_id,
+                            'taskName': task.get('name'),
+                            'source': 'task',
+                            'message': event.get('message', ''),
+                        }
+                    )
+            except Exception:
+                logger.warning(f'No task log stream found for run {run_id} task {selected_task_id}')
+
+        if include_system_events:
+            try:
+                run_logs = await _get_logs_from_stream(
+                    logs_client,
+                    log_group_name,
+                    f'run/{run_id}',
+                    start_time=start_time,
+                    limit=min(limit, 250),
+                    start_from_head=False,
+                )
+                for event in run_logs.get('events', []):
+                    merged_events.append(
+                        {
+                            'timestamp': event.get('timestamp'),
+                            'taskId': None,
+                            'taskName': None,
+                            'source': 'run',
+                            'message': event.get('message', ''),
+                        }
+                    )
+            except Exception:
+                logger.warning(f'No run log stream found for run {run_id}')
+
+        merged_events.sort(key=lambda event: event.get('timestamp') or '', reverse=True)
+        merged_events = merged_events[:limit]
+
+        return {
+            'run': {'id': run_id, 'status': run_status, 'workflowId': workflow_id},
+            'activeTasks': [
+                {
+                    'taskId': task.get('taskId'),
+                    'name': task.get('name'),
+                    'status': task.get('status'),
+                }
+                for task in selected_tasks
+            ],
+            'events': merged_events,
+            'nextToken': None,
+            'diagnostics': {
+                'coarseOnly': len(merged_events) == 0,
+                'notes': []
+                if merged_events
+                else [
+                    'No detailed task logs were available in CloudWatch; falling back to '
+                    'HealthOmics task state only.',
+                ],
+            },
+        }
+    except Exception as e:
+        return await handle_tool_error(ctx, e, f'Error tailing task logs for run {run_id}')

--- a/src/aws-healthomics-mcp-server/awslabs/mcp_lambda_handler/mcp_lambda_handler.py
+++ b/src/aws-healthomics-mcp-server/awslabs/mcp_lambda_handler/mcp_lambda_handler.py
@@ -264,6 +264,7 @@ class MCPLambdaHandler:
                     'list',
                     'get',
                     'search',
+                    'tail',
                     'count',
                     'check',
                     'validate',

--- a/src/aws-healthomics-mcp-server/tests/test_lambda_schema_contract.py
+++ b/src/aws-healthomics-mcp-server/tests/test_lambda_schema_contract.py
@@ -99,10 +99,16 @@ def test_readonly_hint_annotations_for_read_and_write_tools():
     def cancel_aho_run(run_id: str) -> dict:
         return {'run_id': run_id}
 
+    @handler.tool()
+    def tail_aho_run_task_logs(run_id: str) -> dict:
+        return {'run_id': run_id}
+
     list_schema = handler.tools['listAhoWorkflows']
     start_schema = handler.tools['startAhoRun']
     cancel_schema = handler.tools['cancelAhoRun']
+    tail_schema = handler.tools['tailAhoRunTaskLogs']
 
     assert list_schema['annotations']['readOnlyHint'] is True
     assert start_schema['annotations']['readOnlyHint'] is False
     assert cancel_schema['annotations']['readOnlyHint'] is False
+    assert tail_schema['annotations']['readOnlyHint'] is True

--- a/src/aws-healthomics-mcp-server/tests/test_server.py
+++ b/src/aws-healthomics-mcp-server/tests/test_server.py
@@ -44,6 +44,7 @@ def test_server_has_required_tools():
         'GetAHORunManifestLogs',
         'GetAHORunEngineLogs',
         'GetAHOTaskLogs',
+        'TailAHORunTaskLogs',
         'AnalyzeAHORunPerformance',
         'DiagnoseAHORunFailure',
         'PackageAHOWorkflow',


### PR DESCRIPTION
## Summary
- add new read-only `TailAHORunTaskLogs` tool that uses workflow-native inputs (`run_id`, optional `task_id`)
- orchestrate internally across HealthOmics metadata and CloudWatch streams so users never need log-group/stream names
- include graceful fallback diagnostics when detailed CloudWatch task logs are unavailable
- expose tool in both FastMCP server and Lambda wrapper
- classify `tail*` as read-only in Lambda schema annotations

## Files
- `src/aws-healthomics-mcp-server/awslabs/aws_healthomics_mcp_server/tools/workflow_analysis.py`
- `src/aws-healthomics-mcp-server/awslabs/aws_healthomics_mcp_server/server.py`
- `src/aws-healthomics-mcp-server/awslabs/aws_healthomics_mcp_server/lambda_handler.py`
- `src/aws-healthomics-mcp-server/awslabs/mcp_lambda_handler/mcp_lambda_handler.py`
- tests + docs updates

## Validation
- `uv run pytest tests/test_workflow_analysis.py -k tail_run_task_logs -q`
- `uv run pytest tests/test_lambda_schema_contract.py -q`
- `uv run pytest tests/test_server.py -q`
