### PR TITLE
Healthomics: add GetAHORunSummary tool

### DIFF
--- a/src/aws-healthomics-mcp-server/DEPLOYMENT.md
+++ b/src/aws-healthomics-mcp-server/DEPLOYMENT.md
@@ -116,6 +116,7 @@ Use:
 - `GetAHORunManifestLogs`
 - `GetAHOTaskLogs`
 - `TailAHORunTaskLogs`
+- `GetAHORunSummary`
 - `DiagnoseAHORunFailure`
 - `AnalyzeAHORunPerformance`
 

--- a/src/aws-healthomics-mcp-server/README.md
+++ b/src/aws-healthomics-mcp-server/README.md
@@ -63,6 +63,7 @@ This MCP server provides tools for:
 5. **GetAHORunManifestLogs** - Access run manifest logs with runtime information and metrics
 6. **GetAHOTaskLogs** - Get task-specific logs for debugging individual workflow steps
 7. **TailAHORunTaskLogs** - Tail merged recent task/run events without requiring CloudWatch identifiers
+8. **GetAHORunSummary** - Get one-call run summary combining HealthOmics state and recent logs
 
 ### Region Management Tools
 

--- a/src/aws-healthomics-mcp-server/awslabs/aws_healthomics_mcp_server/lambda_handler.py
+++ b/src/aws-healthomics-mcp-server/awslabs/aws_healthomics_mcp_server/lambda_handler.py
@@ -999,6 +999,39 @@ def TailAHORunTaskLogs(
 
 
 @mcp.tool()
+def GetAHORunSummary(
+    run_id: str,
+    include_recent_logs: bool = True,
+    log_limit: int = 50,
+) -> Dict[str, Any]:
+    """Return a one-call operational summary for a workflow run.
+
+    Args:
+        run_id: ID of the run
+        include_recent_logs: Include recent merged run/task logs
+        log_limit: Maximum number of log events in the summary excerpt
+
+    Returns:
+        Dictionary containing run summary information
+    """
+    from awslabs.aws_healthomics_mcp_server.tools.workflow_analysis import get_run_summary
+
+    async def _call():
+        class MockContext:
+            async def error(self, msg):
+                logger.error(msg)
+
+        return await get_run_summary(
+            MockContext(),
+            run_id=run_id,
+            include_recent_logs=include_recent_logs,
+            log_limit=log_limit,
+        )
+
+    return _run_async(_call())
+
+
+@mcp.tool()
 def AnalyzeAHORunPerformance(run_ids: Union[List[str], str]) -> str:
     """Analyze workflow run performance and provide optimization recommendations.
 

--- a/src/aws-healthomics-mcp-server/awslabs/aws_healthomics_mcp_server/server.py
+++ b/src/aws-healthomics-mcp-server/awslabs/aws_healthomics_mcp_server/server.py
@@ -82,6 +82,7 @@ from awslabs.aws_healthomics_mcp_server.tools.run_analysis import analyze_run_pe
 from awslabs.aws_healthomics_mcp_server.tools.run_timeline import generate_run_timeline
 from awslabs.aws_healthomics_mcp_server.tools.troubleshooting import diagnose_run_failure
 from awslabs.aws_healthomics_mcp_server.tools.workflow_analysis import (
+    get_run_summary,
     get_run_engine_logs,
     get_run_logs,
     get_run_manifest_logs,
@@ -141,6 +142,7 @@ This MCP server provides tools for creating, managing, and analyzing genomic wor
 - **GetAHORunEngineLogs**: Retrieve engine logs containing STDOUT and STDERR
 - **GetAHOTaskLogs**: Retrieve logs for specific workflow tasks
 - **TailAHORunTaskLogs**: Tail recent task/run logs for a workflow using run-native inputs
+- **GetAHORunSummary**: Return one-call run summary by combining run/task state with recent logs
 - **AnalyzeAHORunPerformance**: Analyze workflow run performance and resource utilization to provide optimization recommendations
 - **GenerateAHORunTimeline**: Generate a Gantt-style SVG timeline visualization showing task execution phases and parallelism
 
@@ -249,6 +251,7 @@ mcp.tool(name='GetAHORunManifestLogs')(get_run_manifest_logs)
 mcp.tool(name='GetAHORunEngineLogs')(get_run_engine_logs)
 mcp.tool(name='GetAHOTaskLogs')(get_task_logs)
 mcp.tool(name='TailAHORunTaskLogs')(tail_run_task_logs)
+mcp.tool(name='GetAHORunSummary')(get_run_summary)
 mcp.tool(name='AnalyzeAHORunPerformance')(analyze_run_performance)
 mcp.tool(name='GenerateAHORunTimeline')(generate_run_timeline)
 

--- a/src/aws-healthomics-mcp-server/awslabs/aws_healthomics_mcp_server/tools/helper_tools.py
+++ b/src/aws-healthomics-mcp-server/awslabs/aws_healthomics_mcp_server/tools/helper_tools.py
@@ -79,6 +79,7 @@ Recommended sequence:
 - Verify workflow and run IDs exist and are accessible.
 - Check execution role permissions for S3, Logs, and Omics APIs.
 - Retrieve logs with:
+  - `GetAHORunSummary`
   - `GetAHORunLogs`
   - `GetAHORunManifestLogs`
   - `GetAHORunEngineLogs`

--- a/src/aws-healthomics-mcp-server/tests/test_server.py
+++ b/src/aws-healthomics-mcp-server/tests/test_server.py
@@ -45,6 +45,7 @@ def test_server_has_required_tools():
         'GetAHORunEngineLogs',
         'GetAHOTaskLogs',
         'TailAHORunTaskLogs',
+        'GetAHORunSummary',
         'AnalyzeAHORunPerformance',
         'DiagnoseAHORunFailure',
         'PackageAHOWorkflow',


### PR DESCRIPTION
## Summary
- add new read-only `GetAHORunSummary` tool for one-call operational run summaries
- aggregate HealthOmics run/task metadata with recent merged logs from `TailAHORunTaskLogs`
- include coarse fallback diagnostics when detailed logs are unavailable
- expose the tool in both FastMCP server and Lambda wrapper
- update docs/manual references

## Files
- `src/aws-healthomics-mcp-server/awslabs/aws_healthomics_mcp_server/tools/workflow_analysis.py`
- `src/aws-healthomics-mcp-server/awslabs/aws_healthomics_mcp_server/server.py`
- `src/aws-healthomics-mcp-server/awslabs/aws_healthomics_mcp_server/lambda_handler.py`
- tests + docs updates

## Validation
- `uv run pytest tests/test_workflow_analysis.py -k "get_run_summary or tail_run_task_logs" -q`
- `uv run pytest tests/test_lambda_schema_contract.py -q`
- `uv run pytest tests/test_server.py -q`
