### PR TITLE
Document workflow logging schema and event taxonomy

### DIFF
--- a/src/aws-healthomics-mcp-server/DEPLOYMENT.md
+++ b/src/aws-healthomics-mcp-server/DEPLOYMENT.md
@@ -9,6 +9,9 @@ Architecture note:
 See [docs/healthomics-cloudwatch-boundary.md](docs/healthomics-cloudwatch-boundary.md) for
 the decision on workflow-native user interfaces and internal HealthOmics+CloudWatch
 orchestration.
+For structured workflow telemetry contracts, see
+[docs/workflow-logging-schema.md](docs/workflow-logging-schema.md) and
+[docs/workflow-event-taxonomy.md](docs/workflow-event-taxonomy.md).
 
 ## What "deployment" means here
 

--- a/src/aws-healthomics-mcp-server/README.md
+++ b/src/aws-healthomics-mcp-server/README.md
@@ -5,6 +5,9 @@ A Model Context Protocol (MCP) server that provides AI assistants with comprehen
 For workflow deployment steps, see [DEPLOYMENT.md](DEPLOYMENT.md).
 For the Healthomics/CloudWatch architecture boundary, see
 [docs/healthomics-cloudwatch-boundary.md](docs/healthomics-cloudwatch-boundary.md).
+For structured telemetry contracts, see
+[docs/workflow-logging-schema.md](docs/workflow-logging-schema.md) and
+[docs/workflow-event-taxonomy.md](docs/workflow-event-taxonomy.md).
 
 ## Overview
 

--- a/src/aws-healthomics-mcp-server/docs/workflow-event-taxonomy.md
+++ b/src/aws-healthomics-mcp-server/docs/workflow-event-taxonomy.md
@@ -1,0 +1,108 @@
+# Workflow Event Taxonomy (v1)
+
+## Purpose
+
+Define canonical lifecycle event names and semantics for workflow telemetry, independent of
+engine/provider-specific wording. This taxonomy is intended to pair with:
+
+- `docs/workflow-logging-schema.md`
+- HealthOmics run/task lifecycle APIs
+
+## Event Families
+
+### Run-level events
+
+- `RUN_QUEUED`
+  - Run accepted and waiting to start.
+- `RUN_STARTED`
+  - Run entered active execution.
+- `RUN_PROGRESS`
+  - Optional run-level aggregate progress update.
+- `RUN_COMPLETED`
+  - Run finished successfully.
+- `RUN_FAILED`
+  - Run finished with failure.
+- `RUN_CANCELLED`
+  - Run cancelled by user/system.
+
+### Task-level events
+
+- `TASK_QUEUED`
+  - Task admitted and pending scheduling.
+- `TASK_STARTED`
+  - Task execution started.
+- `TASK_PROGRESS`
+  - Task emitted measurable progress.
+- `TASK_RETRY`
+  - Task retry initiated with incremented `attempt`.
+- `TASK_COMPLETED`
+  - Task completed successfully.
+- `TASK_FAILED`
+  - Task failed for current/terminal attempt.
+
+### Data/IO events (optional but recommended)
+
+- `INPUT_IMPORT_STARTED`
+- `INPUT_IMPORT_COMPLETED`
+- `OUTPUT_EXPORT_STARTED`
+- `OUTPUT_EXPORT_COMPLETED`
+
+### Diagnostics events (optional)
+
+- `HEARTBEAT`
+  - Periodic alive signal for long-running tasks.
+- `RESOURCE_USAGE`
+  - Structured resource metrics snapshot.
+- `CHECKPOINT_WRITTEN`
+  - Durable checkpoint emitted.
+
+## Semantics and Constraints
+
+- Events are append-only facts; do not mutate prior event meaning.
+- `*_COMPLETED` and `*_FAILED` are terminal for a given scope and attempt.
+- `TASK_RETRY` must carry incremented `attempt` and reference prior failure.
+- `TASK_PROGRESS` should include structured `progress` object whenever possible.
+- Event timestamps should be UTC RFC3339.
+
+## Mapping from Common HealthOmics/Engine Signals
+
+This table maps frequently observed operational signals to taxonomy events.
+
+| Source signal (example) | Canonical event |
+|---|---|
+| `CREATING_RUN` | `RUN_QUEUED` |
+| `RUNNING_WORKFLOW` | `RUN_STARTED` |
+| `RUN_COMPLETED` | `RUN_COMPLETED` |
+| `RUN_CANCELLED` | `RUN_CANCELLED` |
+| `STARTING_TASK` / `RUNNING_TASK` | `TASK_STARTED` |
+| `TASK_COMPLETED` | `TASK_COMPLETED` |
+| task shell output with measurable units | `TASK_PROGRESS` |
+| task non-zero exit + retry trigger | `TASK_FAILED` then `TASK_RETRY` |
+| `IMPORTING_FILES` | `INPUT_IMPORT_STARTED` |
+| `IMPORT_COMPLETED` | `INPUT_IMPORT_COMPLETED` |
+| `EXPORTING_RESULTS` | `OUTPUT_EXPORT_STARTED` |
+| `EXPORT_COMPLETED` | `OUTPUT_EXPORT_COMPLETED` |
+
+## Retry Model
+
+- `attempt` is 1-based and required for task-level retry-aware events.
+- A retry sequence is:
+  1. `TASK_FAILED` (`attempt=n`)
+  2. `TASK_RETRY` (`attempt=n+1`)
+  3. `TASK_STARTED` (`attempt=n+1`)
+
+## LLM/MCP Consumption Rules
+
+- Prefer canonical event types over parsing free-text messages.
+- Use run/task terminal events to determine completion, not heuristics.
+- Use structured `progress` payload to calculate confidence and percent.
+- If taxonomy signals are absent, degrade to coarse lifecycle mode.
+
+## Example Sequence
+
+1. `RUN_QUEUED`
+2. `RUN_STARTED`
+3. `TASK_STARTED` (`task=IndexReference`, `attempt=1`)
+4. `TASK_PROGRESS` (`completed_units=1.3e9`, `total_units=8.7e9`)
+5. `TASK_COMPLETED`
+6. `RUN_COMPLETED`

--- a/src/aws-healthomics-mcp-server/docs/workflow-logging-schema.md
+++ b/src/aws-healthomics-mcp-server/docs/workflow-logging-schema.md
@@ -1,0 +1,169 @@
+# Workflow Logging Schema (v1)
+
+## Purpose
+
+Define a machine-consumable JSON event schema for workflow/task telemetry emitted to CloudWatch.
+This enables MCP tools to compute meaningful progress, summarize state, and diagnose failures
+without requiring users to understand CloudWatch internals.
+
+This schema is optimized for:
+- MCP server parsing and aggregation
+- LLM consumption
+- WDL/Snakemake/engine-agnostic workflow telemetry
+
+## Scope
+
+- Applies to application-emitted workflow telemetry events.
+- Does not replace native HealthOmics lifecycle events.
+- Intended for task/workflow scripts and wrappers writing JSON log lines.
+
+## Versioning
+
+- `schema_version` is required.
+- Initial version: `1.0`.
+- Backward-incompatible changes require a new major version.
+
+## Canonical Event Envelope
+
+Each log line should be one JSON object with these top-level fields:
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `schema_version` | string | yes | Schema version (for example `1.0`) |
+| `event_time` | string (RFC3339 UTC) | yes | Event timestamp |
+| `event_id` | string | yes | Unique event identifier |
+| `event_type` | string | yes | Event kind (see taxonomy doc) |
+| `severity` | string enum | yes | `DEBUG` \| `INFO` \| `WARN` \| `ERROR` |
+| `workflow_id` | string | yes | HealthOmics workflow ID |
+| `run_id` | string | yes | HealthOmics run ID |
+| `task_id` | string or null | no | HealthOmics task ID (null for run-level events) |
+| `task_name` | string or null | no | Logical task name |
+| `attempt` | integer | no | Retry attempt number (1-based) |
+| `stage` | string | no | Phase within task/run (for example `import`, `align`, `index`) |
+| `message` | string | yes | Human-readable summary |
+| `duration_ms` | integer or null | no | Duration for completed operation |
+| `correlation_id` | string | no | Cross-event correlation key |
+| `progress` | object or null | no | Structured progress payload |
+| `error` | object or null | no | Structured error payload |
+| `labels` | object<string,string> | no | Low-cardinality tags |
+
+## Structured Sub-objects
+
+### `progress` object
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `percent` | number (0-100) | no | Deterministic completion estimate |
+| `completed_units` | integer | no | Completed work units |
+| `total_units` | integer | no | Total work units |
+| `unit` | string | no | Unit label (`records`, `bases`, `chunks`) |
+| `eta_seconds` | integer | no | Estimated remaining time |
+
+At least one of `percent` or (`completed_units` + `total_units`) should be present for
+progress-bearing events.
+
+### `error` object
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `code` | string | no | Stable error code |
+| `category` | string | no | Broad class (`INPUT`, `PERMISSION`, `RESOURCE`, `ENGINE`) |
+| `retryable` | boolean | no | Indicates safe retry |
+| `details` | object | no | Extra structured details |
+
+## Minimal Required Fields by Event Class
+
+- Run-level events: `workflow_id`, `run_id`, `event_type`, `severity`, `message`
+- Task-level events: all above + `task_id`, `task_name`
+- Retry events: task-level + `attempt`
+- Progress events: corresponding level + `progress`
+- Error/failure events: corresponding level + `error` (recommended)
+
+## Example Events
+
+### RUN_STARTED
+
+```json
+{
+  "schema_version": "1.0",
+  "event_time": "2026-02-18T19:17:14Z",
+  "event_id": "evt-0001",
+  "event_type": "RUN_STARTED",
+  "severity": "INFO",
+  "workflow_id": "3677759",
+  "run_id": "3978063",
+  "task_id": null,
+  "task_name": null,
+  "stage": "orchestration",
+  "message": "Run entered RUNNING state",
+  "correlation_id": "run-3978063"
+}
+```
+
+### TASK_PROGRESS (WDL-style indexing)
+
+```json
+{
+  "schema_version": "1.0",
+  "event_time": "2026-02-18T19:35:37Z",
+  "event_id": "evt-0327",
+  "event_type": "TASK_PROGRESS",
+  "severity": "INFO",
+  "workflow_id": "3677759",
+  "run_id": "3978063",
+  "task_id": "3367394",
+  "task_name": "IndexReference",
+  "attempt": 1,
+  "stage": "bwa_index",
+  "message": "BWT iteration progress",
+  "progress": {
+    "completed_units": 1299999996,
+    "total_units": 8786896236,
+    "unit": "bases"
+  },
+  "correlation_id": "run-3978063-task-3367394"
+}
+```
+
+### TASK_FAILED
+
+```json
+{
+  "schema_version": "1.0",
+  "event_time": "2026-02-18T20:03:20Z",
+  "event_id": "evt-1041",
+  "event_type": "TASK_FAILED",
+  "severity": "ERROR",
+  "workflow_id": "3677759",
+  "run_id": "3978063",
+  "task_id": "3367394",
+  "task_name": "IndexReference",
+  "attempt": 2,
+  "stage": "bwa_index",
+  "message": "Task failed with non-zero exit code",
+  "duration_ms": 164320,
+  "error": {
+    "code": "EXIT_NON_ZERO",
+    "category": "ENGINE",
+    "retryable": false,
+    "details": {
+      "exit_code": 137
+    }
+  },
+  "correlation_id": "run-3978063-task-3367394"
+}
+```
+
+## Client Interpretation Guidance
+
+- Treat HealthOmics run/task state as authoritative lifecycle truth.
+- Treat structured workflow telemetry as progress/detail enrichment.
+- Ignore unknown fields for forward compatibility.
+- Prefer structured `progress` over regex parsing unstructured messages.
+
+## Relationship to MCP tools
+
+When this schema is present in task logs:
+- `GetAHORunProgress` can compute higher-confidence progress.
+- `GetAHORunSummary` can produce cleaner, machine-grounded highlights.
+- `TailAHORunTaskLogs` can surface structured signals with less ambiguity.


### PR DESCRIPTION
## Summary
- add a versioned structured logging schema for workflow/task telemetry (`workflow-logging-schema.md`)
- add canonical workflow event taxonomy and mapping guidance (`workflow-event-taxonomy.md`)
- link both docs from README and DEPLOYMENT entry points

## Included docs
- `src/aws-healthomics-mcp-server/docs/workflow-logging-schema.md`
  - canonical JSON envelope
  - required fields (`workflow_id`, `run_id`, `task_id`, `attempt`, `stage`, `event_type`, `severity`, `duration_ms`)
  - structured `progress`/`error` sub-objects
  - versioning and examples
- `src/aws-healthomics-mcp-server/docs/workflow-event-taxonomy.md`
  - canonical run/task lifecycle events
  - retry semantics and attempt handling
  - mapping from common HealthOmics/engine signals
  - consumption guidance for MCP/LLM clients

## Why
This establishes a machine-consumable telemetry contract so progress/summaries can rely on structured signals instead of free-text parsing when workflows emit telemetry.

Closes #30
Closes #31
