### PR TITLE
Fix ChatGPT connector discovery/auth flow and document deployment

### DIFF
--- a/src/aws-healthomics-mcp-server/CHANGELOG.md
+++ b/src/aws-healthomics-mcp-server/CHANGELOG.md
@@ -9,4 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Initial project setup
+- Connector compatibility deployment runbook in `DEPLOYMENT.md` for:
+  - ChatGPT Apps action discovery and refresh/republish behavior
+  - Mixed-auth route model (`tools/list` unauthenticated, `tools/call` authenticated)
+  - OAuth metadata and callback URL operations
+  - "No actions available" troubleshooting and verification checklist
+
+### Changed
+
+- README now links directly to the connector compatibility deployment section.

--- a/src/aws-healthomics-mcp-server/DEPLOYMENT.md
+++ b/src/aws-healthomics-mcp-server/DEPLOYMENT.md
@@ -231,8 +231,8 @@ February 13, 2026.
 
 JWT-protected routes:
 
-- `ANY /`
-- `ANY /{proxy+}`
+- `ANY /` (optional in mixed-auth mode; see below)
+- `ANY /{proxy+}` (optional in mixed-auth mode; see below)
 
 Public (no auth) routes:
 
@@ -242,6 +242,18 @@ Public (no auth) routes:
 - `POST /register`
 - `ANY /callback`
 - `ANY /logout`
+
+### Mixed-auth mode for ChatGPT action discovery
+
+If ChatGPT shows "No actions are available for this app" even though OAuth discovery works,
+enable mixed-auth behavior:
+
+1. API Gateway `ANY /` and `ANY /{proxy+}` routes use `AuthorizationType=NONE`.
+2. Lambda MCP handler enforces auth only for `tools/call`.
+3. `initialize` and `tools/list` remain unauthenticated so connector action discovery succeeds.
+
+This preserves read of the tool catalog during connector registration while keeping actual
+tool execution protected by OAuth bearer validation.
 
 ### JWT authorizer
 
@@ -277,6 +289,80 @@ new server code or changing tool schemas, do all of the following in ChatGPT App
 
 If this is skipped, clients may continue using a stale tool list/schema even when the
 Lambda deployment is already updated.
+
+## March 2026 connector compatibility updates
+
+The deployment now includes compatibility hardening for ChatGPT Apps connector discovery
+and OAuth integration.
+
+### 1) MCP path contract
+
+- OAuth metadata endpoints are served under stage root:
+  - `https://<api-id>.execute-api.<region>.amazonaws.com/<stage>/.well-known/oauth-authorization-server`
+  - `https://<api-id>.execute-api.<region>.amazonaws.com/<stage>/.well-known/openid-configuration`
+- JSON-RPC MCP endpoint is served at:
+  - `https://<api-id>.execute-api.<region>.amazonaws.com/<stage>/mcp`
+
+If the connector is pointed at `/stable` (without `/mcp` support in server path resolution),
+tool discovery can fail or show no actions.
+
+### 2) Mixed-auth discovery model
+
+To support connector action discovery while keeping tool execution protected:
+
+1. API Gateway `ANY /` and `ANY /{proxy+}` are set to `AuthorizationType=NONE`.
+2. Lambda MCP handler enforces OAuth bearer auth for `tools/call`.
+3. `initialize` and `tools/list` stay unauthenticated.
+
+Expected behavior:
+
+- `initialize` succeeds without token.
+- `tools/list` succeeds without token and returns full tool catalog.
+- `tools/call` without bearer token returns unauthorized.
+
+### 3) OAuth metadata completeness
+
+Deployment includes extended discovery metadata required by strict clients:
+
+- `userinfo_endpoint`
+- `revocation_endpoint`
+- `jwks_uri`
+- `id_token_signing_alg_values_supported`
+- `subject_types_supported`
+
+### 4) Cognito callback URL operations
+
+ChatGPT Apps can generate a new callback URL on reconnect. The Cognito app client callback
+list must include the newly issued URL before creating or reconnecting the app.
+
+Operational notes:
+
+- Keep `https://chatgpt.com/connector_platform_oauth_redirect` in callbacks.
+- Add the latest `https://chatgpt.com/connector/oauth/<id>` URL when reconnecting.
+- If dynamic registration is unstable, set OAuth Client ID explicitly in ChatGPT App setup.
+
+### 5) Connector verification checklist
+
+After deploy and reconnect, verify all of the following:
+
+1. ChatGPT App "Actions" count is non-zero and tool list is visible.
+2. `tools/list` includes expected operations (for example `CancelAHORun`,
+   `ListAHOReferenceStores`, `GetAHOServerManual`).
+3. `StartAHORun` schema marks only core fields as required:
+   `workflow_id`, `role_arn`, `name`, `output_uri`.
+4. `SearchGenomicsFiles.search_terms` is `array[string]`.
+5. `CancelAHORun` is callable from connector.
+
+### 6) Fast triage for "No actions available"
+
+If ChatGPT still shows "No actions are available for this app":
+
+1. Confirm MCP server URL in app matches the deployed stage base URL.
+2. Confirm JSON-RPC path resolution reaches `/mcp` on the backend.
+3. Refresh actions in ChatGPT Apps and republish.
+4. Reconnect app to regenerate OAuth callback, then add that callback to Cognito.
+5. Validate OAuth discovery endpoint returns complete metadata.
+6. Validate `tools/list` over HTTP directly against `/mcp`.
 
 ## Common deployment failures
 

--- a/src/aws-healthomics-mcp-server/README.md
+++ b/src/aws-healthomics-mcp-server/README.md
@@ -10,6 +10,9 @@ For structured telemetry contracts, see
 [docs/workflow-event-taxonomy.md](docs/workflow-event-taxonomy.md).
 For retention/redaction/query operations guidance, see
 [docs/logging-operations-policy.md](docs/logging-operations-policy.md).
+For ChatGPT Apps connector operations (OAuth callbacks, action discovery, `/mcp` path,
+mixed-auth model, and "No actions available" triage), see
+[DEPLOYMENT.md#march-2026-connector-compatibility-updates](DEPLOYMENT.md#march-2026-connector-compatibility-updates).
 
 ## Overview
 

--- a/src/aws-healthomics-mcp-server/awslabs/aws_healthomics_mcp_server/lambda_handler.py
+++ b/src/aws-healthomics-mcp-server/awslabs/aws_healthomics_mcp_server/lambda_handler.py
@@ -25,6 +25,7 @@ from typing import Any, Dict, List, Optional, Union
 
 from awslabs.mcp_lambda_handler import MCPLambdaHandler
 from loguru import logger
+from jwt import InvalidTokenError, PyJWKClient, decode as jwt_decode
 
 # Import version info
 from awslabs.aws_healthomics_mcp_server import __version__
@@ -119,6 +120,14 @@ def get_oauth_config() -> Dict[str, str]:
             'OAUTH_TOKEN_ENDPOINT',
             'https://carlsberg-healthomics-auth.auth.eu-west-1.amazoncognito.com/oauth2/token'
         ),
+        'userinfo_endpoint': os.environ.get(
+            'OAUTH_USERINFO_ENDPOINT',
+            'https://carlsberg-healthomics-auth.auth.eu-west-1.amazoncognito.com/oauth2/userInfo'
+        ),
+        'revocation_endpoint': os.environ.get(
+            'OAUTH_REVOCATION_ENDPOINT',
+            'https://carlsberg-healthomics-auth.auth.eu-west-1.amazoncognito.com/oauth2/revoke'
+        ),
         'client_id': os.environ.get(
             'OAUTH_CLIENT_ID',
             '6r52ekr37jn84nlusjgn6j7f8m'
@@ -148,11 +157,16 @@ def get_oauth_metadata(base_url: str = '') -> Dict[str, Any]:
         'issuer': config['issuer'],
         'authorization_endpoint': config['authorization_endpoint'],
         'token_endpoint': config['token_endpoint'],
+        'userinfo_endpoint': config['userinfo_endpoint'],
+        'revocation_endpoint': config['revocation_endpoint'],
+        'jwks_uri': f'{config["issuer"].rstrip("/")}/.well-known/jwks.json',
         'response_types_supported': ['code'],
         'grant_types_supported': ['authorization_code', 'refresh_token'],
         'code_challenge_methods_supported': ['S256'],
         'token_endpoint_auth_methods_supported': ['none', 'client_secret_post'],
         'scopes_supported': ['openid', 'email', 'profile'],
+        'id_token_signing_alg_values_supported': ['RS256'],
+        'subject_types_supported': ['public'],
     }
 
     # Add registration endpoint for RFC 7591 Dynamic Client Registration
@@ -224,7 +238,26 @@ def handle_dynamic_client_registration(event: Dict[str, Any]) -> Optional[Dict[s
     return None
 
 
-def get_base_url(event: Dict[str, Any]) -> str:
+def _extract_mount_prefix(path: str) -> str:
+    """Extract optional mount prefix (for example `/mcp`) from request path."""
+    if not path:
+        return ''
+
+    suffixes = [
+        '/.well-known/oauth-authorization-server',
+        '/.well-known/openid-configuration',
+        '/register',
+        '/callback',
+        '/logout',
+    ]
+    for suffix in suffixes:
+        if path.endswith(suffix):
+            prefix = path[: -len(suffix)]
+            return prefix if prefix and prefix != '/' else ''
+    return ''
+
+
+def get_base_url(event: Dict[str, Any], path: str = '') -> str:
     """Extract base URL from the Lambda event.
 
     Args:
@@ -236,27 +269,31 @@ def get_base_url(event: Dict[str, Any]) -> str:
     # Try to get from requestContext (API Gateway v2)
     request_context = event.get('requestContext', {})
 
+    mount_prefix = _extract_mount_prefix(path)
+
     # API Gateway HTTP API (v2)
     if 'domainName' in request_context:
         domain = request_context['domainName']
         stage = request_context.get('stage', '')
+        base = f'https://{domain}'
         if stage and stage != '$default':
-            return f'https://{domain}/{stage}'
-        return f'https://{domain}'
+            base = f'{base}/{stage}'
+        return f'{base}{mount_prefix}'
 
     # API Gateway REST API (v1)
     if 'domain_name' in request_context:
         domain = request_context['domain_name']
         stage = request_context.get('stage', '')
+        base = f'https://{domain}'
         if stage:
-            return f'https://{domain}/{stage}'
-        return f'https://{domain}'
+            base = f'{base}/{stage}'
+        return f'{base}{mount_prefix}'
 
     # Fallback to headers
     headers = event.get('headers', {})
     host = headers.get('Host') or headers.get('host', '')
     if host:
-        return f'https://{host}'
+        return f'https://{host}{mount_prefix}'
 
     return ''
 
@@ -272,7 +309,7 @@ def handle_oauth_discovery(event: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     """
     # Get the path from the event
     path = event.get('path', '') or event.get('rawPath', '')
-    base_url = get_base_url(event)
+    base_url = get_base_url(event, path)
 
     # Check for OAuth discovery endpoints
     if path.endswith('/.well-known/oauth-authorization-server') or \
@@ -309,10 +346,79 @@ def handle_oauth_discovery(event: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     return None
 
 
+_JWKS_CLIENT: Optional[PyJWKClient] = None
+
+
+def _get_jwks_client() -> PyJWKClient:
+    """Get cached JWK client for Cognito issuer."""
+    global _JWKS_CLIENT
+
+    if _JWKS_CLIENT is not None:
+        return _JWKS_CLIENT
+
+    issuer = get_oauth_config()['issuer'].rstrip('/')
+    jwks_url = f'{issuer}/.well-known/jwks.json'
+    _JWKS_CLIENT = PyJWKClient(jwks_url)
+    return _JWKS_CLIENT
+
+
+def authorize_mcp_tool_call(event: Dict[str, Any], headers: Dict[str, str]) -> Optional[str]:
+    """Authorize `tools/call` requests while allowing discovery without auth.
+
+    Returns:
+        None when authorized, otherwise an error message.
+    """
+    # If API Gateway authorizer already validated JWT, trust those claims.
+    claims = (
+        event.get('requestContext', {})
+        .get('authorizer', {})
+        .get('jwt', {})
+        .get('claims', {})
+    )
+    if claims:
+        return None
+
+    auth_header = headers.get('authorization', '')
+    if not auth_header.startswith('Bearer '):
+        return 'Unauthorized: Bearer token required for tools/call'
+
+    token = auth_header[len('Bearer ') :].strip()
+    if not token:
+        return 'Unauthorized: Bearer token required for tools/call'
+
+    config = get_oauth_config()
+    issuer = config['issuer'].rstrip('/')
+    client_id = config['client_id']
+
+    try:
+        signing_key = _get_jwks_client().get_signing_key_from_jwt(token)
+        decoded = jwt_decode(
+            token,
+            signing_key.key,
+            algorithms=['RS256'],
+            issuer=issuer,
+            options={'verify_aud': False},
+        )
+    except InvalidTokenError as exc:
+        logger.warning(f'JWT validation failed for tools/call: {exc}')
+        return 'Unauthorized: invalid bearer token'
+    except Exception as exc:
+        logger.warning(f'JWT verification error for tools/call: {exc}')
+        return 'Unauthorized: invalid bearer token'
+
+    token_audience = decoded.get('aud')
+    token_client_id = decoded.get('client_id')
+    if token_audience != client_id and token_client_id != client_id:
+        return 'Unauthorized: token audience/client mismatch'
+
+    return None
+
+
 # Create the MCP Lambda handler instance (stateless)
 mcp = MCPLambdaHandler(
     name='awslabs.aws-healthomics-mcp-server',
     version=__version__,
+    authorize_tool_call=authorize_mcp_tool_call,
 )
 
 def _register_lambda_tool(tool_name: str, tool_fn: Any) -> None:

--- a/src/aws-healthomics-mcp-server/awslabs/mcp_lambda_handler/mcp_lambda_handler.py
+++ b/src/aws-healthomics-mcp-server/awslabs/mcp_lambda_handler/mcp_lambda_handler.py
@@ -84,6 +84,7 @@ class MCPLambdaHandler:
         name: str,
         version: str = '1.0.0',
         session_store: Optional[Union[SessionStore, str]] = None,
+        authorize_tool_call: Optional[Callable[[Dict[str, Any], Dict[str, str]], Optional[str]]] = None,
     ):
         """Initialize the MCP handler.
 
@@ -94,12 +95,16 @@ class MCPLambdaHandler:
                          - None for no sessions
                          - A SessionStore instance
                          - A string for DynamoDB table name (for backwards compatibility)
+            authorize_tool_call: Optional authorization callback for `tools/call`.
+                         Receives raw event and normalized headers, returns
+                         None when authorized or an error message when denied.
 
         """
         self.name = name
         self.version = version
         self.tools: Dict[str, Dict] = {}
         self.tool_implementations: Dict[str, Callable] = {}
+        self.authorize_tool_call = authorize_tool_call
 
         # Configure session storage
         if session_store is None:
@@ -482,6 +487,17 @@ class MCPLambdaHandler:
 
             # Handle tool calls
             if request.method == 'tools/call' and request.params:
+                if self.authorize_tool_call:
+                    auth_error = self.authorize_tool_call(event, headers)
+                    if auth_error:
+                        return self._create_error_response(
+                            -32001,
+                            auth_error,
+                            request.id,
+                            status_code=401,
+                            session_id=session_id,
+                        )
+
                 tool_name = request.params.get('name')
                 tool_args = request.params.get('arguments', {})
 

--- a/src/aws-healthomics-mcp-server/tests/test_lambda_schema_contract.py
+++ b/src/aws-healthomics-mcp-server/tests/test_lambda_schema_contract.py
@@ -150,3 +150,35 @@ def test_content_type_with_charset_is_accepted():
     assert response['statusCode'] == 200
     assert 'result' in payload
     assert 'tools' in payload['result']
+
+
+def test_tools_call_can_be_authorized_with_callback():
+    """tools/call should honor authorize_tool_call callback."""
+    handler = MCPLambdaHandler(
+        'test-server',
+        authorize_tool_call=lambda _event, _headers: 'Unauthorized: Bearer token required for tools/call',
+    )
+
+    @handler.tool()
+    def ping() -> dict:
+        return {'ok': True}
+
+    event = {
+        'requestContext': {'http': {'method': 'POST'}},
+        'headers': {'content-type': 'application/json'},
+        'body': json.dumps(
+            {
+                'jsonrpc': '2.0',
+                'id': '3',
+                'method': 'tools/call',
+                'params': {'name': 'ping', 'arguments': {}},
+            }
+        ),
+    }
+
+    response = handler.handle_request(event, context=None)
+    payload = json.loads(response['body'])
+
+    assert response['statusCode'] == 401
+    assert payload['error']['code'] == -32001
+    assert 'Unauthorized' in payload['error']['message']


### PR DESCRIPTION
## Summary
- allow ChatGPT connector action discovery in mixed-auth mode by keeping initialize and tools/list available while enforcing auth on tools/call
- add JWT bearer validation fallback for tools/call when API Gateway context is absent
- improve MCP base URL/path handling for mounted /mcp endpoint and expand OAuth metadata fields
- add schema contract test coverage for authorized tools/call behavior
- document March 2026 connector compatibility runbook in deployment docs

## Validation
- cd src/aws-healthomics-mcp-server && uv run pytest tests/test_lambda_schema_contract.py

## Notes
- intentionally excluded src/aws-healthomics-mcp-server/uv.lock from this PR (local lock drift only)
