### PR TITLE
Fix HealthOmics MCP OAuth registration endpoint discovery

### DIFF
--- a/src/aws-healthomics-mcp-server/awslabs/aws_healthomics_mcp_server/lambda_handler.py
+++ b/src/aws-healthomics-mcp-server/awslabs/aws_healthomics_mcp_server/lambda_handler.py
@@ -243,12 +243,17 @@ def _extract_mount_prefix(path: str) -> str:
     if not path:
         return ''
 
+    if '/mcp/' in path:
+        prefix = path.split('/mcp/', 1)[0]
+        return prefix if prefix and prefix != '/' else ''
+
     suffixes = [
         '/.well-known/oauth-authorization-server',
         '/.well-known/openid-configuration',
         '/register',
         '/callback',
         '/logout',
+        '/mcp',
     ]
     for suffix in suffixes:
         if path.endswith(suffix):
@@ -266,34 +271,42 @@ def get_base_url(event: Dict[str, Any], path: str = '') -> str:
     Returns:
         Base URL string (e.g., https://api.example.com/stage)
     """
+    explicit_base_url = os.environ.get('MCP_SERVER_BASE_URL', '').strip()
+    if explicit_base_url:
+        return explicit_base_url.rstrip('/')
+
     # Try to get from requestContext (API Gateway v2)
     request_context = event.get('requestContext', {})
-
     mount_prefix = _extract_mount_prefix(path)
+    stage = request_context.get('stage', '')
+    stage_prefix = f'/{stage}' if stage and stage != '$default' else ''
+
+    def _normalize_base(base: str) -> str:
+        if mount_prefix:
+            if stage_prefix and (
+                mount_prefix == stage_prefix or mount_prefix.startswith(f'{stage_prefix}/')
+            ):
+                return f'{base}{mount_prefix}'
+            if stage_prefix:
+                return f'{base}{stage_prefix}{mount_prefix}'
+            return f'{base}{mount_prefix}'
+        if stage_prefix:
+            return f'{base}{stage_prefix}'
+        return base
+
+    headers = event.get('headers', {})
+    host = headers.get('Host') or headers.get('host', '')
+    scheme = headers.get('X-Forwarded-Proto') or headers.get('x-forwarded-proto') or 'https'
+    if host:
+        return _normalize_base(f'{scheme}://{host}')
 
     # API Gateway HTTP API (v2)
     if 'domainName' in request_context:
-        domain = request_context['domainName']
-        stage = request_context.get('stage', '')
-        base = f'https://{domain}'
-        if stage and stage != '$default':
-            base = f'{base}/{stage}'
-        return f'{base}{mount_prefix}'
+        return _normalize_base(f'https://{request_context["domainName"]}')
 
     # API Gateway REST API (v1)
     if 'domain_name' in request_context:
-        domain = request_context['domain_name']
-        stage = request_context.get('stage', '')
-        base = f'https://{domain}'
-        if stage:
-            base = f'{base}/{stage}'
-        return f'{base}{mount_prefix}'
-
-    # Fallback to headers
-    headers = event.get('headers', {})
-    host = headers.get('Host') or headers.get('host', '')
-    if host:
-        return f'https://{host}{mount_prefix}'
+        return _normalize_base(f'https://{request_context["domain_name"]}')
 
     return ''
 

--- a/src/aws-healthomics-mcp-server/tests/test_lambda_handler.py
+++ b/src/aws-healthomics-mcp-server/tests/test_lambda_handler.py
@@ -1,0 +1,106 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for OAuth discovery path handling in the HealthOmics Lambda handler."""
+
+import json
+
+from awslabs.aws_healthomics_mcp_server.lambda_handler import (
+    _extract_mount_prefix,
+    get_base_url,
+    handle_oauth_discovery,
+)
+
+
+def test_extract_mount_prefix_strips_mcp_subpath() -> None:
+    """Discovery under /mcp should still resolve to the stage root."""
+    path = '/stable/mcp/.well-known/openid-configuration'
+
+    assert _extract_mount_prefix(path) == '/stable'
+
+
+def test_get_base_url_prefers_explicit_env(monkeypatch) -> None:
+    """Explicit MCP server base URL should override request reconstruction."""
+    monkeypatch.setenv(
+        'MCP_SERVER_BASE_URL',
+        'https://osgs2j07zf.execute-api.eu-west-1.amazonaws.com/stable',
+    )
+    event = {
+        'requestContext': {'domainName': 'example.execute-api.eu-west-1.amazonaws.com', 'stage': 'stable'},
+        'headers': {'host': 'example.execute-api.eu-west-1.amazonaws.com'},
+    }
+
+    base_url = get_base_url(event, '/stable/mcp/.well-known/openid-configuration')
+
+    assert base_url == 'https://osgs2j07zf.execute-api.eu-west-1.amazonaws.com/stable'
+
+
+def test_get_base_url_does_not_duplicate_stage_for_mcp_discovery(monkeypatch) -> None:
+    """Base URL reconstruction should not append the API stage twice."""
+    monkeypatch.delenv('MCP_SERVER_BASE_URL', raising=False)
+    event = {
+        'requestContext': {'domainName': 'example.execute-api.eu-west-1.amazonaws.com', 'stage': 'stable'},
+        'headers': {
+            'host': 'example.execute-api.eu-west-1.amazonaws.com',
+            'x-forwarded-proto': 'https',
+        },
+    }
+
+    base_url = get_base_url(event, '/stable/mcp/.well-known/openid-configuration')
+
+    assert base_url == 'https://example.execute-api.eu-west-1.amazonaws.com/stable'
+
+
+def test_handle_oauth_discovery_emits_stage_root_registration_endpoint(monkeypatch) -> None:
+    """OpenID metadata should advertise the stage-root register endpoint."""
+    monkeypatch.delenv('MCP_SERVER_BASE_URL', raising=False)
+    event = {
+        'rawPath': '/stable/mcp/.well-known/openid-configuration',
+        'requestContext': {'domainName': 'example.execute-api.eu-west-1.amazonaws.com', 'stage': 'stable'},
+        'headers': {
+            'host': 'example.execute-api.eu-west-1.amazonaws.com',
+            'x-forwarded-proto': 'https',
+        },
+    }
+
+    response = handle_oauth_discovery(event)
+    assert response is not None
+
+    payload = json.loads(response['body'])
+
+    assert payload['registration_endpoint'] == (
+        'https://example.execute-api.eu-west-1.amazonaws.com/stable/register'
+    )
+
+
+def test_handle_oauth_discovery_supports_mcp_relative_path(monkeypatch) -> None:
+    """Requests whose raw path omits the stage should still emit the stage-root register endpoint."""
+    monkeypatch.delenv('MCP_SERVER_BASE_URL', raising=False)
+    event = {
+        'rawPath': '/mcp/.well-known/openid-configuration',
+        'requestContext': {'domainName': 'example.execute-api.eu-west-1.amazonaws.com', 'stage': 'stable'},
+        'headers': {
+            'host': 'example.execute-api.eu-west-1.amazonaws.com',
+            'x-forwarded-proto': 'https',
+        },
+    }
+
+    response = handle_oauth_discovery(event)
+    assert response is not None
+
+    payload = json.loads(response['body'])
+
+    assert payload['registration_endpoint'] == (
+        'https://example.execute-api.eu-west-1.amazonaws.com/stable/register'
+    )


### PR DESCRIPTION
## Summary
- fix HealthOmics MCP OAuth discovery base URL reconstruction for staged and `/mcp` discovery paths
- prefer explicit `MCP_SERVER_BASE_URL` when emitting discovery metadata
- add regression tests for `registration_endpoint` generation

## Problem
New ChatGPT/Codex MCP onboarding hit the HealthOmics OAuth discovery endpoints but received malformed metadata such as:
- `/stable/stable/register`
- `/stable/stable/mcp/register`

That broke dynamic client registration flow even though `initialize` and `tools/list` were otherwise healthy.

## Changes
- teach mount-prefix extraction to treat `/mcp/.well-known/...` as transport subpaths
- normalize reconstructed stage-root base URLs to avoid duplicate stage segments
- use `MCP_SERVER_BASE_URL` directly when present
- add focused tests for stage-root and `/mcp` discovery variants

## Verification
- `uv run pytest tests/test_lambda_handler.py -q`
- `uv run pytest tests/test_lambda_schema_contract.py -q`

Closes #43.
